### PR TITLE
Fix IndexOutOfRangeException

### DIFF
--- a/UdpHosts/GameServer/Channel.cs
+++ b/UdpHosts/GameServer/Channel.cs
@@ -94,6 +94,7 @@ namespace GameServer
                     // de-xor data
                     var x = packet.PacketData.Length >> 3;
                     var data = packet.PacketData.ToArray();
+                    var dataTmp = Array.Empty<byte>();
 
                     if (x > 0)
                     {
@@ -104,8 +105,11 @@ namespace GameServer
                             uSpan[i] ^= xorULong[packet.Header.ResendCount];
                         }
 
-                        data = MemoryMarshal.Cast<ulong, byte>(uSpan).ToArray();
+                        dataTmp = MemoryMarshal.Cast<ulong, byte>(uSpan).ToArray(); // override old size
                     }
+
+                    for (int i = 0; i < dataTmp.Length; i++) // copy back
+                        data[i] = dataTmp[i];
 
                     for (var i = x * 8; i < packet.PacketData.Length; i++)
                     {


### PR DESCRIPTION
Hi
When i run firefall and loading map in GameServer i get error. I debug and try fix then.
I get error when "packet.PacketData.Length = 25".
Please check it make sense.

Error:
`[21:06:32 VRB] --> Matrix: MsgID = ClientStatus (25)
[21:06:32 VRB] <-- Matrix: MsgID = 0x29
[21:06:32 VRB] <- Matrix SeqNum =  4
Unhandled exception. System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at GameServer.Channel.Process(CancellationToken ct) in D:\Programming\CSharp\Firefall\PIN\UdpHosts\GameServer\Channel.cs:line 75
   at GameServer.NetworkClient.NetworkTick(Double deltaTime, UInt64 currTime, CancellationToken ct) in D:\Programming\CSharp\Firefall\PIN\UdpHosts\GameServer\NetworkClient.cs:line 87
   at GameServer.Shard.NetworkTick(Double deltaTime, UInt64 currTime, CancellationToken ct) in D:\Programming\CSharp\Firefall\PIN\UdpHosts\GameServer\Shard.cs:line 72
   at GameServer.Shard.RunThread(CancellationToken ct) in D:\Programming\CSharp\Firefall\PIN\UdpHosts\GameServer\Shard.cs:line 132
   at Shared.Udp.Utils.<>c__DisplayClass1_0.<RunThread>b__0(Object o) in D:\Programming\CSharp\Firefall\PIN\Lib\Shared.Udp\Utils.cs:line 21
   at System.Threading.ThreadHelper.ThreadStart_Context(Object state)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.ThreadHelper.ThreadStart(Object obj)`

My sdk:
D:\>dotnet --info
.NET SDK (reflecting any global.json):
 Version:   5.0.401
 Commit:    4bef5f3dbf

Runtime Environment:
 OS Name:     Windows
 OS Version:  10.0.16299
 OS Platform: Windows
 RID:         win10-x64
 Base Path:   C:\Program Files\dotnet\sdk\5.0.401\

Host (useful for support):
  Version: 5.0.10
  Commit:  e1825b4928

.NET SDKs installed:
  5.0.401 [C:\Program Files\dotnet\sdk]

.NET runtimes installed:
  Microsoft.AspNetCore.App 3.1.19 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
  Microsoft.AspNetCore.App 5.0.10 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
  Microsoft.NETCore.App 3.1.19 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  Microsoft.NETCore.App 5.0.10 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  Microsoft.WindowsDesktop.App 3.1.19 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
  Microsoft.WindowsDesktop.App 5.0.10 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]