### PR TITLE
GameServer configuration, expanded web API capabilities, DX improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 .idea/
 Webhosts/WebHost.WebAsset/Assets/*
 !Webhosts/WebHost.WebAsset/Assets/.gitkeep
-UdpHosts/GameServer/config/settings.development.json
+UdpHosts/GameServer/App.config
 
 # User-specific files
 *.rsuser

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .idea/
 Webhosts/WebHost.WebAsset/Assets/*
 !Webhosts/WebHost.WebAsset/Assets/.gitkeep
+UdpHosts/GameServer/config/settings.development.json
 
 # User-specific files
 *.rsuser

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,13 @@
 
 ### Changed
 
-- Added configuration for the game server. You can edit the settings.json for working defaults and settings.development.json for local settings.
-  Currently, the only option is the log level
-- Added cli options parsing. Currently, the only option is the log level.
-- Added 404 handling to the web server pipeline which prints the contents of requests which produce 404 responses as warnings.
-- Changed missing MSGid parser logging to include the first message in log level warning as well
-- Added ClientEventController with a corresponding endpoint to receive the respective events from the client
+- Added individual .bat files for each game service pointing directly to the respective `bin\debug` folder.
+- Added configuration for the game server. You can edit `settings.json` in the `config` directory when adding working defaults and add a `settings.development.json` in the same folder for local/individual settings.
+  Currently, the only option is the log level.
+- Added cli options parsing. Currently, the only option is the log level. Specifying wrong options will not stop the server from starting.
+- Added 404 handling to the web server pipeline which prints the contents of 404-producing requests as warnings to see what's missing.
+- Changed 'missing MSGid' logging to include the details (1st message) in log level warning instead of verbose.
+- Added ClientEventController with a corresponding endpoint to receive the events from the client. Currently, only the client uptime seems to be posted on exit of the game.
 - Update documentation regarding the usage of web hosts
 - Turn Firefall specific location finder to a common location provider
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Changed
 
+- Added configuration for the game server. You can edit the settings.json for working defaults and settings.development.json for local settings.
+  Currently, the only option is the log level
+- Added cli options parsing. Currently, the only option is the log level.
+- Added 404 handling to the web server pipeline which prints the contents of requests which produce 404 responses as warnings.
+- Changed missing MSGid parser logging to include the first message in log level warning as well
+- Added ClientEventController with a corresponding endpoint to receive the respective events from the client
 - Update documentation regarding the usage of web hosts
 - Turn Firefall specific location finder to a common location provider
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 ### Changed
 
 - Added individual .bat files for each game service pointing directly to the respective `bin\debug` folder.
-- Added configuration for the game server. You can edit `settings.json` in the `config` directory when adding working defaults and add a `settings.development.json` in the same folder for local/individual settings.
-  Currently, the only option is the log level.
+- Added configuration for the game server. You can edit the `App.config` file in the `GameServer` project root for local settings and add working defaults in `App.Default.config`.
+  `App.config` will be generated from `App.Default.config` if not present before build.
+  Currently, the only option present is the Serilog log level.
 - Added cli options parsing. Currently, the only option is the log level. Specifying wrong options will not stop the server from starting.
 - Added 404 handling to the web server pipeline which prints the contents of 404-producing requests as warnings to see what's missing.
 - Changed 'missing MSGid' logging to include the details (1st message) in log level warning instead of verbose.

--- a/Lib/Shared.Common/Shared.Common.csproj
+++ b/Lib/Shared.Common/Shared.Common.csproj
@@ -13,9 +13,9 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
         <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
-        <PackageReference Include="Serilog" Version="2.10.0" />
-        <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
-        <PackageReference Include="System.Text.Json" Version="6.0.1" />
+        <PackageReference Include="Serilog" Version="2.12.0" />
+        <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+        <PackageReference Include="System.Text.Json" Version="6.0.6" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Lib/Shared.Udp/Shared.Udp.csproj
+++ b/Lib/Shared.Udp/Shared.Udp.csproj
@@ -12,9 +12,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+        <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
         <PackageReference Include="System.Buffers" Version="4.5.1" />
-        <PackageReference Include="System.Memory" Version="4.5.4" />
+        <PackageReference Include="System.Memory" Version="4.5.5" />
         <PackageReference Include="System.Net.Sockets" Version="4.3.0" />
         <PackageReference Include="System.Threading.Tasks.Dataflow" Version="6.0.0" />
     </ItemGroup>

--- a/Lib/Shared.Web/BaseWebServer.cs
+++ b/Lib/Shared.Web/BaseWebServer.cs
@@ -63,6 +63,7 @@ namespace Shared.Web
 
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddSwaggerGen();
             _ = services.AddControllers()
                         .AddJsonOptions(options =>
                                         {
@@ -75,10 +76,20 @@ namespace Shared.Web
             ConfigureChildServices(services);
         }
 
-        protected virtual void ConfigureChildServices(IServiceCollection services) { }
+        protected virtual void ConfigureChildServices(IServiceCollection services)
+        {
+            services.AddSwaggerGen();
+        }
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
+
+            app.UseSwagger();
+            app.UseSwaggerUI(c =>
+                             {
+                                 c.SwaggerEndpoint("/swagger/v1/swagger.json", "Firefall API");
+                             });
+
             if (env.IsDevelopment())
             {
                 _ = app.UseDeveloperExceptionPage();

--- a/Lib/Shared.Web/Shared.Web.csproj
+++ b/Lib/Shared.Web/Shared.Web.csproj
@@ -14,6 +14,9 @@
         <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
         <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.4.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.4.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.4.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Lib/Shared.Web/Shared.Web.csproj
+++ b/Lib/Shared.Web/Shared.Web.csproj
@@ -12,8 +12,8 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
-        <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+        <PackageReference Include="Serilog.AspNetCore" Version="6.0.1" />
         <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.4.0" />
         <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.4.0" />
         <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.4.0" />

--- a/PIN.sln
+++ b/PIN.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29409.12
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32929.385
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Shared.Common", "Lib\Shared.Common\Shared.Common.csproj", "{B0713AD9-4EF4-4740-93A5-6F756BA130E4}"
 EndProject
@@ -48,11 +48,12 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_Solution Items", "_Solution Items", "{1191B69C-BCE5-484D-B938-030EBE130B2B}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		.gitignore = .gitignore
+		CHANGELOG.md = CHANGELOG.md
 		PIN.sln.DotSettings = PIN.sln.DotSettings
 		README.md = README.md
 		SharedAssemblyInfo.cs = SharedAssemblyInfo.cs
 		Start.cmd = Start.cmd
-		CHANGELOG.md = CHANGELOG.md
 	EndProjectSection
 EndProject
 Global

--- a/StartGameServer.bat
+++ b/StartGameServer.bat
@@ -1,0 +1,1 @@
+start /D UdpHosts\GameServer\bin\Debug\net5.0 UdpHosts\GameServer\bin\Debug\net5.0\GameServer.exe

--- a/StartMatrixServer.bat
+++ b/StartMatrixServer.bat
@@ -1,0 +1,1 @@
+start /D UdpHosts\MatrixServer\bin\Debug\net5.0 UdpHosts\MatrixServer\bin\Debug\net5.0\MatrixServer.exe

--- a/StartWebHostManager.bat
+++ b/StartWebHostManager.bat
@@ -1,0 +1,1 @@
+start /D WebHostManager\bin\Debug\net5.0 WebHostManager\bin\Debug\net5.0\WebHostManager.exe

--- a/UdpHosts/GameServer/App.Default.config
+++ b/UdpHosts/GameServer/App.Default.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <appSettings>
+    <add key="serilog:minimum-level" value="Debug"/>
+    <!-- More settings here -->
+  </appSettings>
+</configuration>

--- a/UdpHosts/GameServer/CliOptions.cs
+++ b/UdpHosts/GameServer/CliOptions.cs
@@ -1,0 +1,19 @@
+﻿using CommandLine;
+using Serilog.Events;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GameServer
+{
+    /// <summary>
+    /// Declares the options which are supported on the CLI
+    /// </summary>
+    public class CliOptions
+    {
+        [Option('l', "logLevel", Default = null, Required = false, HelpText = "The log level. Any messages below this level will not be printed to the console")]
+        public LogEventLevel? LogLevel { get; set; }
+    }
+}

--- a/UdpHosts/GameServer/Controllers/Base.cs
+++ b/UdpHosts/GameServer/Controllers/Base.cs
@@ -25,18 +25,18 @@ namespace GameServer.Controllers
 
         public abstract void Init(INetworkClient client, IPlayer player, IShard shard);
 
-        public void HandlePacket(INetworkClient client, IPlayer player, ulong EntityID, byte MsgID, GamePacket packet)
+        public void HandlePacket(INetworkClient client, IPlayer player, ulong entityId, byte msgId, GamePacket packet)
         {
-            var method = ReflectionUtils.FindMethodsByAttribute<MessageIDAttribute>(this).Where(mi => mi.GetAttribute<MessageIDAttribute>().MsgID == MsgID).FirstOrDefault();
+            var method = ReflectionUtils.FindMethodsByAttribute<MessageIDAttribute>(this).FirstOrDefault(mi => mi.GetAttribute<MessageIDAttribute>().MsgID == msgId);
 
             if (method == null)
             {
-                Log.Verbose("---> Unrecognized MsgID for GSS Packet; Controller = {0} Entity = 0x{1:X8} MsgID = {2}!", ControllerID, EntityID, MsgID);
-                Program.Logger.Warning(">  {0}", BitConverter.ToString(packet.PacketData.ToArray()).Replace("-", " "));
+                Log.Warning("---> Unrecognized MsgID for GSS Packet; Controller = {0} Entity = 0x{1:X8} MsgID = {2}!", ControllerID, entityId, msgId);
+                Log.Warning(">  {0}", BitConverter.ToString(packet.PacketData.ToArray()).Replace("-", " "));
                 return;
             }
 
-            _ = method.Invoke(this, new object[] { client, player, EntityID, packet });
+            _ = method.Invoke(this, new object[] { client, player, entityId, packet });
         }
     }
 }

--- a/UdpHosts/GameServer/GameServer.csproj
+++ b/UdpHosts/GameServer/GameServer.csproj
@@ -28,6 +28,12 @@
     <ProjectReference Include="..\..\Lib\Shared.Udp\Shared.Udp.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="App.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 
   <Target Name="Create_App-config_from_App-Default-config" Condition="!Exists('App.config')" BeforeTargets="Build">
     <Copy SourceFiles="App.Default.config" DestinationFiles="App.config"></Copy>

--- a/UdpHosts/GameServer/GameServer.csproj
+++ b/UdpHosts/GameServer/GameServer.csproj
@@ -13,6 +13,8 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="CommandLineParser" Version="2.9.1" />
+        <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
         <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
         <PackageReference Include="System.Buffers" Version="4.5.1" />
         <PackageReference Include="System.IO.Pipelines" Version="6.0.1" />
@@ -23,6 +25,15 @@
     <ItemGroup>
         <ProjectReference Include="..\..\Lib\Shared.Common\Shared.Common.csproj" />
         <ProjectReference Include="..\..\Lib\Shared.Udp\Shared.Udp.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <None Update="config\settings.development.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
+      <None Update="config\settings.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
     </ItemGroup>
 
 </Project>

--- a/UdpHosts/GameServer/GameServer.csproj
+++ b/UdpHosts/GameServer/GameServer.csproj
@@ -28,9 +28,6 @@
     </ItemGroup>
 
     <ItemGroup>
-      <None Update="config\settings.development.json">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </None>
       <None Update="config\settings.json">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>

--- a/UdpHosts/GameServer/GameServer.csproj
+++ b/UdpHosts/GameServer/GameServer.csproj
@@ -15,10 +15,10 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Serilog.Settings.AppSettings" Version="2.2.2" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
-    <PackageReference Include="System.IO.Pipelines" Version="6.0.1" />
-    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.IO.Pipelines" Version="6.0.3" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
   </ItemGroup>
 

--- a/UdpHosts/GameServer/GameServer.csproj
+++ b/UdpHosts/GameServer/GameServer.csproj
@@ -1,39 +1,36 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-        <TargetFramework>net5.0</TargetFramework>
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <LangVersion>latest</LangVersion>
-        <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    </PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <LangVersion>latest</LangVersion>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <Compile Include="..\..\SharedAssemblyInfo.cs" Link="Properties\SharedAssemblyInfo.cs" />
-    </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\SharedAssemblyInfo.cs" Link="Properties\SharedAssemblyInfo.cs" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <PackageReference Include="CommandLineParser" Version="2.9.1" />
-        <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-        <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
-        <PackageReference Include="System.Buffers" Version="4.5.1" />
-        <PackageReference Include="System.IO.Pipelines" Version="6.0.1" />
-        <PackageReference Include="System.Memory" Version="4.5.4" />
-        <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Serilog.Settings.AppSettings" Version="2.2.2" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <PackageReference Include="System.IO.Pipelines" Version="6.0.1" />
+    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\..\Lib\Shared.Common\Shared.Common.csproj" />
-        <ProjectReference Include="..\..\Lib\Shared.Udp\Shared.Udp.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Lib\Shared.Common\Shared.Common.csproj" />
+    <ProjectReference Include="..\..\Lib\Shared.Udp\Shared.Udp.csproj" />
+  </ItemGroup>
 
-    <ItemGroup>
-      <None Update="config\settings.development.json" Condition="Exists('config\settings.development.json')">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </None>
-      <None Update="config\settings.json">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </None>
-    </ItemGroup>
+
+  <Target Name="Create_App-config_from_App-Default-config" Condition="!Exists('App.config')" BeforeTargets="Build">
+    <Copy SourceFiles="App.Default.config" DestinationFiles="App.config"></Copy>
+  </Target>
 
 </Project>

--- a/UdpHosts/GameServer/GameServer.csproj
+++ b/UdpHosts/GameServer/GameServer.csproj
@@ -14,7 +14,6 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="Serilog.Settings.AppSettings" Version="2.2.2" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />

--- a/UdpHosts/GameServer/GameServer.csproj
+++ b/UdpHosts/GameServer/GameServer.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -28,6 +28,9 @@
     </ItemGroup>
 
     <ItemGroup>
+      <None Update="config\settings.development.json" Condition="Exists('config\settings.development.json')">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
       <None Update="config\settings.json">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>

--- a/UdpHosts/GameServer/GameServerSettings.cs
+++ b/UdpHosts/GameServer/GameServerSettings.cs
@@ -1,0 +1,20 @@
+﻿using Serilog.Events;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GameServer
+{
+    /// <summary>
+    /// Holds the settings for the server
+    /// </summary>
+    public class GameServerSettings
+    {
+        /// <summary>
+        /// The log level to use for the logger. Any messages below this level won't be printed to console.
+        /// </summary>
+        public LogEventLevel? LogLevel { get; set; }
+    }
+}

--- a/UdpHosts/GameServer/Program.cs
+++ b/UdpHosts/GameServer/Program.cs
@@ -1,30 +1,92 @@
-﻿using Serilog;
+﻿using CommandLine;
+using Newtonsoft.Json;
+using Serilog;
+using Serilog.Events;
 using Shared.Common;
 using Shared.Udp;
 using System;
 using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.IO;
 
 namespace GameServer
 {
     internal static class Program
     {
         public static ILogger Logger { get; private set; }
+        public static GameServerSettings GameServerSettings { get; private set; }
 
         private static void Main(string[] arguments)
         {
+
+            LoadSettings();
+            ParseAndApplyCliOptions(arguments);
+
             Logger = new LoggerConfiguration()
-                     .MinimumLevel.Verbose()
+                     .MinimumLevel.Is(GameServerSettings.LogLevel.Value!)
                      .WriteTo.Console(theme: SerilogTheme.Custom)
                      .CreateLogger();
 
+
+            // TODO: add DI?
+
             PacketServer.Logger = Logger;
 
-            // TODO: Handle/allow args and configuration, add DI?
+            
             Span<byte> ranSpan = stackalloc byte[8];
             new Random().NextBytes(ranSpan.Slice(2, 6));
             var serverId = BinaryPrimitives.ReadUInt64LittleEndian(ranSpan);
             var server = new GameServer(25001, serverId);
             server.Run();
+        }
+
+        /// <summary>
+        /// Load the settings from the current directory.
+        /// "settings.development.json" takes precedence over "settings.json"
+        /// <remarks>The ConfigurationExtensions used in the WebHostManager are only available for the Windows platform, hence we need to implement it manually</remarks>
+        /// </summary>
+        private static void LoadSettings()
+        {
+            var basePath = Path.Combine(Directory.GetCurrentDirectory(), "config");
+            var developmentSettingsPath = Path.Combine(basePath, "settings.development.json");
+            var settingsPath = Path.Combine(basePath, "settings.json");
+
+            var sourcePath = File.Exists(developmentSettingsPath) ? developmentSettingsPath : settingsPath;
+
+            try
+            {
+                var json = File.ReadAllText(sourcePath);
+                GameServerSettings = JsonConvert.DeserializeObject<GameServerSettings>(json);
+            }
+            catch (Exception e)
+            {
+                Console.Error.WriteLine($"Error when trying to read settings from \"{sourcePath}\" : {e}{Environment.NewLine}Using builtin default settings");
+                GameServerSettings = new GameServerSettings { LogLevel = LogEventLevel.Verbose };
+            }
+
+        }
+
+        private static void ParseAndApplyCliOptions(IEnumerable<string> arguments)
+        {
+            Parser.Default.ParseArguments<CliOptions>(arguments)
+                  .WithParsed(RunOptions)
+                  .WithNotParsed(HandleParseError);
+        }
+
+        private static void RunOptions(CliOptions options)
+        {
+            if (options.LogLevel != null)
+            {
+                GameServerSettings.LogLevel = options.LogLevel;
+            }
+        }
+
+        private static void HandleParseError(IEnumerable<Error> errors)
+        {
+            foreach (var error in errors)
+            {
+                Console.Error.WriteLine("Error when parsing options: " + error);
+            }
         }
     }
 }

--- a/UdpHosts/GameServer/Program.cs
+++ b/UdpHosts/GameServer/Program.cs
@@ -18,9 +18,22 @@ namespace GameServer
 
         private static void Main(string[] arguments)
         {
-
+            // TODO: add DI?
+            LoadAppSettings();
             ParseAndApplyCliOptions(arguments);
+            SetupLogger();
 
+
+            var serverId = GenerateServerId();
+            var server = new GameServer(25001, serverId);
+            server.Run();
+        }
+
+        /// <summary>
+        /// Set the logger up
+        /// </summary>
+        private static void SetupLogger()
+        {
             var loggerConfig = new LoggerConfiguration()
                                .ReadFrom.AppSettings()
                                .WriteTo.Console(theme: SerilogTheme.Custom);
@@ -33,19 +46,35 @@ namespace GameServer
             Logger = loggerConfig
                 .CreateLogger();
 
-
-            // TODO: add DI?
-
             PacketServer.Logger = Logger;
-
-            
-            Span<byte> ranSpan = stackalloc byte[8];
-            new Random().NextBytes(ranSpan.Slice(2, 6));
-            var serverId = BinaryPrimitives.ReadUInt64LittleEndian(ranSpan);
-            var server = new GameServer(25001, serverId);
-            server.Run();
         }
 
+        /// <summary>
+        /// Load the settings from App.config
+        /// </summary>
+        private static void LoadAppSettings()
+        {
+            GameServerSettings = new GameServerSettings();
+            // no settings as of yet, expand this function should the need arise
+        }
+
+        /// <summary>
+        /// Generate the Server Id
+        /// ToDo: Incorporate the Sql Node Number as per https://gist.github.com/SilentCLD/881839a9f45578f1618db012fc789a71
+        /// </summary>
+        /// <returns></returns>
+        private static ulong GenerateServerId()
+        {
+            Span<byte> ranSpan = stackalloc byte[8];
+            new Random().NextBytes(ranSpan.Slice(2, 6));
+            var ret = BinaryPrimitives.ReadUInt64LittleEndian(ranSpan);
+            return ret;
+        }
+
+        /// <summary>
+        /// Parse the options passed via the command line and overwrite settings from the config
+        /// </summary>
+        /// <param name="arguments"></param>
         private static void ParseAndApplyCliOptions(IEnumerable<string> arguments)
         {
             Parser.Default.ParseArguments<CliOptions>(arguments)
@@ -53,6 +82,10 @@ namespace GameServer
                   .WithNotParsed(HandleParseError);
         }
 
+        /// <summary>
+        /// Handle the parsed options, essentially overwriting already present settings loaded from App.config
+        /// </summary>
+        /// <param name="options"></param>
         private static void RunOptions(CliOptions options)
         {
             if (options.LogLevel != null)
@@ -61,6 +94,10 @@ namespace GameServer
             }
         }
 
+        /// <summary>
+        /// If errors occur during the parsing of CLI options, they should be handled here
+        /// </summary>
+        /// <param name="errors"></param>
         private static void HandleParseError(IEnumerable<Error> errors)
         {
             foreach (var error in errors)

--- a/UdpHosts/GameServer/Program.cs
+++ b/UdpHosts/GameServer/Program.cs
@@ -1,13 +1,10 @@
 ﻿using CommandLine;
-using Newtonsoft.Json;
 using Serilog;
-using Serilog.Events;
 using Shared.Common;
 using Shared.Udp;
 using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
-using System.IO;
 
 namespace GameServer
 {

--- a/UdpHosts/GameServer/config/settings.development.json
+++ b/UdpHosts/GameServer/config/settings.development.json
@@ -1,3 +1,3 @@
 {
-  "logLevel": "Debug"
+  "logLevel": "Verbose"
 }

--- a/UdpHosts/GameServer/config/settings.development.json
+++ b/UdpHosts/GameServer/config/settings.development.json
@@ -1,3 +1,0 @@
-{
-  "logLevel": "Verbose"
-}

--- a/UdpHosts/GameServer/config/settings.development.json
+++ b/UdpHosts/GameServer/config/settings.development.json
@@ -1,0 +1,3 @@
+{
+  "logLevel": "Debug"
+}

--- a/UdpHosts/GameServer/config/settings.json
+++ b/UdpHosts/GameServer/config/settings.json
@@ -1,0 +1,3 @@
+{
+  "logLevel": "Verbose"
+}

--- a/UdpHosts/GameServer/config/settings.json
+++ b/UdpHosts/GameServer/config/settings.json
@@ -1,3 +1,0 @@
-{
-  "logLevel": "Verbose"
-}

--- a/UdpHosts/MatrixServer/MatrixServer.csproj
+++ b/UdpHosts/MatrixServer/MatrixServer.csproj
@@ -14,7 +14,7 @@
 
     <ItemGroup>
         <PackageReference Include="Serilog.Settings.AppSettings" Version="2.2.2" />
-        <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+        <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/UdpHosts/MatrixServer/MatrixServer.csproj
+++ b/UdpHosts/MatrixServer/MatrixServer.csproj
@@ -13,6 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="Serilog.Settings.AppSettings" Version="2.2.2" />
         <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
     </ItemGroup>
 

--- a/WebHostManager/Program.cs
+++ b/WebHostManager/Program.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
 using Serilog;
 using Shared.Web;
 using System;

--- a/WebHostManager/WebHostManager.csproj
+++ b/WebHostManager/WebHostManager.csproj
@@ -29,10 +29,10 @@
         <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.7" />
         <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
         <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.2.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-        <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
-        <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+        <PackageReference Include="Serilog.AspNetCore" Version="6.0.1" />
+        <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
         <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
     </ItemGroup>
 

--- a/WebHosts/WebHost.Chat/WebHost.Chat.csproj
+++ b/WebHosts/WebHost.Chat/WebHost.Chat.csproj
@@ -12,8 +12,8 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
-        <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+        <PackageReference Include="Serilog.AspNetCore" Version="6.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/WebHosts/WebHost.ClientApi/Controllers/ClientEventController.cs
+++ b/WebHosts/WebHost.ClientApi/Controllers/ClientEventController.cs
@@ -18,7 +18,7 @@ namespace WebHost.ClientApi.Controllers
         [HttpPost]
         public object Post([FromBody]ClientEvent payload)
         {
-            Log.Logger.Information(JsonConvert.SerializeObject(payload));
+            Log.Logger.Verbose(JsonConvert.SerializeObject(payload));
             return new { };
         }
     }

--- a/WebHosts/WebHost.ClientApi/Controllers/ClientEventController.cs
+++ b/WebHosts/WebHost.ClientApi/Controllers/ClientEventController.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
 using Serilog;
 using System;
 using System.Collections.Generic;
@@ -17,7 +18,7 @@ namespace WebHost.ClientApi.Controllers
         [HttpPost]
         public object Post([FromBody]ClientEvent payload)
         {
-            Log.Logger.Information(payload.ToString());
+            Log.Logger.Information(JsonConvert.SerializeObject(payload));
             return new { };
         }
     }

--- a/WebHosts/WebHost.ClientApi/Controllers/ClientEventController.cs
+++ b/WebHosts/WebHost.ClientApi/Controllers/ClientEventController.cs
@@ -1,11 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc;
-using Newtonsoft.Json;
 using Serilog;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Text.Json;
 using WebHost.ClientApi.Models.ClientEvent;
 
 namespace WebHost.ClientApi.Controllers
@@ -18,7 +13,7 @@ namespace WebHost.ClientApi.Controllers
         [HttpPost]
         public object Post([FromBody]ClientEvent payload)
         {
-            Log.Logger.Verbose(JsonConvert.SerializeObject(payload));
+            Log.Logger.Verbose(JsonSerializer.Serialize(payload));
             return new { };
         }
     }

--- a/WebHosts/WebHost.ClientApi/Controllers/ClientEventController.cs
+++ b/WebHosts/WebHost.ClientApi/Controllers/ClientEventController.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using WebHost.ClientApi.Models.ClientEvent;
+
+namespace WebHost.ClientApi.Controllers
+{
+    [Route("api/v1")]
+    [ApiController]
+    public class ClientEventController : ControllerBase
+    {
+        [Route("client_event")]
+        [HttpPost]
+        public object Post([FromBody]ClientEvent payload)
+        {
+            Log.Logger.Information(payload.ToString());
+            return new { };
+        }
+    }
+}

--- a/WebHosts/WebHost.ClientApi/Models/Accounts/CreateAccountPost.cs
+++ b/WebHosts/WebHost.ClientApi/Models/Accounts/CreateAccountPost.cs
@@ -1,31 +1,32 @@
-﻿using Newtonsoft.Json;
+﻿
+using System.Text.Json.Serialization;
 
 namespace WebHost.ClientApi.Models.Accounts
 {
     public class CreateAccountPost
     {
-        [JsonProperty("email")]
+        [JsonPropertyName("email")]
         public string Email { get; set; }
 
-        [JsonProperty("confirm_email")]
+        [JsonPropertyName("confirm_email")]
         public string ConfirmEmail { get; set; }
 
-        [JsonProperty("password")]
+        [JsonPropertyName("password")]
         public string Password { get; set; }
 
-        [JsonProperty("confirm_password")]
+        [JsonPropertyName("confirm_password")]
         public string ConfirmPassword { get; set; }
 
-        [JsonProperty("birthday")]
+        [JsonPropertyName("birthday")]
         public string Birthday { get; set; }
 
-        [JsonProperty("country")]
+        [JsonPropertyName("country")]
         public string Country { get; set; }
 
-        [JsonProperty("email_optin")]
+        [JsonPropertyName("email_optin")]
         public bool EmailOptIn { get; set; }
 
-        [JsonProperty("referral_key")]
+        [JsonPropertyName("referral_key")]
         public string ReferralKey { get; set; }
     }
 }

--- a/WebHosts/WebHost.ClientApi/Models/ClientEvent/ClientEvent.cs
+++ b/WebHosts/WebHost.ClientApi/Models/ClientEvent/ClientEvent.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WebHost.ClientApi.Models.ClientEvent
+{
+    /// <summary>
+    /// Raised when something happens on the client, eg. logout
+    /// </summary>
+    public class ClientEvent
+    {
+        /// <summary>
+        /// Presumably the type of the event, in all observed cases "event"
+        /// </summary>
+        public string Event { get; set; }
+
+        /// <summary>
+        /// The action which was performed within the client
+        /// </summary>
+        public string Action { get; set; }
+
+        /// <summary>
+        /// The data of the event
+        /// </summary>
+        public ClientEventData Data { get; set; }
+    }
+}

--- a/WebHosts/WebHost.ClientApi/Models/ClientEvent/ClientEventData.cs
+++ b/WebHosts/WebHost.ClientApi/Models/ClientEvent/ClientEventData.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WebHost.ClientApi.Models.ClientEvent
+{
+    /// <summary>
+    /// Transmitted to the API within a <see cref="ClientEvent"/>
+    /// </summary>
+    public class ClientEventData
+    {
+        /// <summary>
+        /// (unknown so far, presumably more details about the event)
+        /// </summary>
+        public string Message { get; set; }
+
+        /// <summary>
+        /// The source of the event within the client (eg. "login")
+        /// </summary>
+        public string Source { get; set; }
+
+        /// <summary>
+        /// The the actual data in form of a JSON string
+        /// </summary>
+        public string Data { get; set; }
+    }
+}


### PR DESCRIPTION
Hello there!
This is probably my first "real" PR on GitHub so don't be surprised if something seems off / a bit unconventional.

I'm still in the process of understanding the architecture of the project so my changes mostly focus on DX stuff and Web API changes since that's what I work on in my job.

My changes mostly focus on enabling the configuration of the `GameServer` and expanding the capabilities of the web API.

0) Individual start.bat files
  I went ahead and added start.bat files with one for each service. The Start.cmd didn't work for me and I didn't want to "fix" something that may not be broken at all.
  They each point to the respective `bin\debug\net5.0` folder.

1) Added Swagger to the WebAPI
  Swagger is an incredibly useful tool when building a web API. Developers access the swagger page of any WebHost by opening https://localhost:[port]/swagger/index.html on their browser.

2) Added special logging of 404 producing requests
  The Web API isn't complete yet. For instance doing /rui on the client shows that a lot of endpoints are still missing. Therefore it makes sense to log these requests under warning.
 Later on, we could maybe collect them in a dev database or file so ToDos can be created more easily. This unless there's a way to collect all endpoints used by the client and how they're used.

3) Added `ClientEventController` 
  On closing, the game client sends `POST` requests to `api/v1/client_event`.
  I added the respective endpoint and received data is printed to the console (log level .
  Inspecting the `WebHost` log showed that solely the client uptime is logged to the API, but other things might be as well.

4) Made `GameServer` configurable via settings file and CLI
  What really slowed down my process of getting into the UDP API was the sheer stream of verbose messages on the console. It was quite overwhelming and didn't bring much use to me as a beginner.
  Therefore, I went ahead and made the log level configurable both via CLI and a `settings.json` file stored under `[server_dir]/config/settings.json`.
  4.1) ~~`settings.json`
      Utilizing the same extensions as used in `BaseWebServer.cs:39` was not possible since those are Windows-specific, hence the settings are parsed via a manual approach. As I understood so far, keeping the project platform-agnostic is crucial.
      To prevent git-change-hell, one can go ahead and add a `settings.development.json` file in the same directory.
      It takes full precedence over `settings.json` (no mixing between those files yet).
      The file was added to `.gitignore` to prevent accidental commits. It'll still be shown in VS.
      The `.gitignore` was added to the solution items because it wasn't already.~~ (see update below)
  4.2) CLI Options (`CommandLineParser`)
      In general, CLI Options override configured options for quick and dirty tinkering.
      Faulty provided options will also not prevent the server from starting to keep the behavior unchanged, though this should be changed in the future.
      [CommandLineParser](https://github.com/commandlineparser/commandline) allows for easy handling also produces some nice output

    <details>
    
      <summary>Example output</summary>
      
      ```text
      GameServer 1.1.0.0
      Copyright ©2019-2021 by The Melding Wars
      
      -l, --logLevel    The log level. Any messages below this level will not be printed to the console
      
      --help            Display this help screen.
      
      --version         Display version information.
      ```

    </details>
    
5) Change `'missing MSGid'` logging to log level `warning` (`Base.cs:34`)
  When encountering an unknown `MSGid`, both the message and its details are printed to console.
  The details, however, were previously only logged as `verbose`.
  Thus, when setting the log level to `warning`, one only saw the prints of the messages which did not provide any meaningful value without knowing about *why* such output could be produced.

6) Automatic refactoring
  I performed some automatic refactorings as suggested by the IDE. They're mostly located in `Base.cs`



Should there be any issues with the changes or the structure of the PR (perhaps too detailed?), please let me know! 
Feedback is highly appreciated 😁 