### PR TITLE
Map vehicle component types to sdb_guids

### DIFF
--- a/UdpHosts/GameServer/StaticDB/Records/vcs/ComponentType.cs
+++ b/UdpHosts/GameServer/StaticDB/Records/vcs/ComponentType.cs
@@ -1,0 +1,38 @@
+﻿namespace GameServer.Data.SDB.Records.vcs;
+
+// There are 30 distinct sdb_guid values in vcs::BaseComponentDef
+// Each sdb_guid appears in only one of <Type>ComponentDef tables
+public enum ComponentType : uint
+{
+    Scoping = 3866376917,
+    Driver = 1562371278,
+    Passenger = 2202208390,
+    Ability = 3048110324,
+    Damage = 3737859927,
+    StatusEffect = 3322729247,
+    Turret = 533726263,
+    Deployable = 3213454533,
+    SpawnPoint = 1715213540,
+
+    HullSegment = 555024461,
+    Warpaint = 1238758490,
+    WheelBase = 2550758801,
+    Transmission = 3101116909,
+    Suspension = 2505221195,
+    Engine  = 868401361,
+    Steering = 4196128104,
+    Braking = 3431260985,
+    Aerodynamics = 1921341588,
+    HeadLight = 2674988324,
+    Exhaust = 2154345371,
+    FlightPath = 2075941479,
+    Visual = 2131841188,
+    Light = 1648495344,
+    LightSensor = 1780124415,
+    GroundEffects = 3716493569,
+    Camera = 4175714783,
+    GroundPath = 1292643894,
+    SimpleShieldGenerator = 22217899,
+    DropPod = 1851570801,
+    Cloak = 3678315516,
+}

--- a/UdpHosts/GameServer/StaticDB/SDBUtils.cs
+++ b/UdpHosts/GameServer/StaticDB/SDBUtils.cs
@@ -225,72 +225,70 @@ public class SDBUtils
             Turrets = new List<TurretComponentDef>(),
             Deployables = new List<DeployableComponentDef>(),
         };
+
         foreach (var baseComponent in baseComponents.Values)
         {
-            // We don't know how to identify the type, so we look each one up in every table of interest.
-            // Not sure if the sdb_guid somehow hints at where to find it
             var componentId = baseComponent.Id;
-            var scopingComponent = SDBInterface.GetScopingComponentDef(componentId);
-            var driverComponent = SDBInterface.GetDriverComponentDef(componentId);
-            var passengerComponent = SDBInterface.GetPassengerComponentDef(componentId);
-            var abilityComponent = SDBInterface.GetAbilityComponentDef(componentId);
-            var damageComponent = SDBInterface.GetDamageComponentDef(componentId);
-            var statusEffectComponent = SDBInterface.GetStatusEffectComponentDef(componentId);
-            var turretComponent = SDBInterface.GetTurretComponentDef(componentId);
-            var deployableComponent = SDBInterface.GetDeployableComponentDef(componentId);
-            var spawnPointComponent = SDBInterface.GetSpawnPointComponentDef(componentId);
 
-            if (scopingComponent != null)
+            var componentType = (ComponentType)baseComponent.SdbGuid;
+            switch (componentType)
             {
-                result.ScopeRange = scopingComponent.ScopeRange;
-                result.SpawnHeight = scopingComponent.SpawnHeight;
-                result.SpawnAbility = scopingComponent.SpawnAbility;
-                result.DespawnAbility = scopingComponent.DespawnAbility;
-            }
+                case ComponentType.Scoping:
+                    var scopingComponent = SDBInterface.GetScopingComponentDef(componentId);
+                    result.ScopeRange = scopingComponent.ScopeRange;
+                    result.SpawnHeight = scopingComponent.SpawnHeight;
+                    result.SpawnAbility = scopingComponent.SpawnAbility;
+                    result.DespawnAbility = scopingComponent.DespawnAbility;
+                    break;
 
-            if (driverComponent != null)
-            {
-                result.HasDriverSeat = true;
-                result.DriverPosture = driverComponent.Posture;
-            }
+                case ComponentType.Driver:
+                    var driverComponent = SDBInterface.GetDriverComponentDef(componentId);
+                    result.HasDriverSeat = true;
+                    result.DriverPosture = driverComponent.Posture;
+                    break;
 
-            if (passengerComponent != null)
-            {
-                result.MaxPassengers = passengerComponent.MaxPassengers;
-                result.PassengerPosture = passengerComponent.Posture;
-                result.HasActivePassenger = passengerComponent.ActivePassenger == 1;
-            }
+                case ComponentType.Passenger:
+                    var passengerComponent = SDBInterface.GetPassengerComponentDef(componentId);
+                    result.MaxPassengers = passengerComponent.MaxPassengers;
+                    result.PassengerPosture = passengerComponent.Posture;
+                    result.HasActivePassenger = passengerComponent.ActivePassenger == 1;
+                    break;
 
-            if (abilityComponent != null)
-            {
-                result.Abilities.Add(abilityComponent);
-            }
+                case ComponentType.Ability:
+                    var abilityComponent = SDBInterface.GetAbilityComponentDef(componentId);
+                    result.Abilities.Add(abilityComponent);
+                    break;
 
-            if (damageComponent != null)
-            {
-                result.DeathAbility = damageComponent.DeathAbility;
-                result.MaxHitPoints = damageComponent.MaxHitPoints;
-                result.DamageResponse = damageComponent.DamageResponse;
-            }
+                case ComponentType.Damage:
+                    var damageComponent = SDBInterface.GetDamageComponentDef(componentId);
+                    result.DeathAbility = damageComponent.DeathAbility;
+                    result.MaxHitPoints = damageComponent.MaxHitPoints;
+                    result.DamageResponse = damageComponent.DamageResponse;
+                    break;
 
-            if (statusEffectComponent != null)
-            {
-                result.StatusFxId = statusEffectComponent.StatusFxId;
-            }
+                case ComponentType.StatusEffect:
+                    var statusEffectComponent = SDBInterface.GetStatusEffectComponentDef(componentId);
+                    result.StatusFxId = statusEffectComponent.StatusFxId;
+                    break;
 
-            if (turretComponent != null)
-            {
-                result.Turrets.Add(turretComponent);
-            }
+                case ComponentType.Turret:
+                    var turretComponent = SDBInterface.GetTurretComponentDef(componentId);
+                    result.Turrets.Add(turretComponent);
+                    break;
 
-            if (deployableComponent != null)
-            {
-                result.Deployables.Add(deployableComponent);
-            }
+                case ComponentType.Deployable:
+                    var deployableComponent = SDBInterface.GetDeployableComponentDef(componentId);
+                    result.Deployables.Add(deployableComponent);
+                    break;
 
-            if (spawnPointComponent != null)
-            {
-                // TODO: Probably for allowing spawning into the vehicle
+                case ComponentType.SpawnPoint:
+                    // TODO: Probably for allowing spawning into the vehicle
+                    // var spawnPointComponent = SDBInterface.GetSpawnPointComponentDef(componentId);
+                    break;
+
+                default:
+                    // Console.WriteLine($"Unhandled vehicle component, id: {componentId}, type: {componentType}");
+                    break;
             }
         }
 


### PR DESCRIPTION
Each distinct value from `sdb_guid` column in `vcs::BaseComponentDef` seem to tied to specific `<Type>ComponentDef` table. I've updated `SDBUtils.GetDetailedVehicleInfo()` based on that.

Number of component records with matching sdb_guid per every `<Type>ComponentDef` table: https://gist.github.com/SzymonKaminski/13ecea37072ab452fbe17ed897579652