### PR TITLE
Update Operand enum values, RegistryOp method

### DIFF
--- a/UdpHosts/GameServer/Data/CharacterInventory.cs
+++ b/UdpHosts/GameServer/Data/CharacterInventory.cs
@@ -417,7 +417,7 @@ public class CharacterInventory
         if (sdb_id != 0)
         {
             // Update Visuals
-            _loadouts[(uint)loadoutId].LoadoutConfigs[0].Visuals = _loadouts[(uint)loadoutId].LoadoutConfigs[0].Visuals.Append(new LoadoutConfig_Visual() { ItemSdbId = sdb_id, VisualType = visual, Data1 = 0, Data2 = 0, Transform = []}).ToArray();
+            _loadouts[(uint)loadoutId].LoadoutConfigs[0].Visuals = _loadouts[(uint)loadoutId].LoadoutConfigs[0].Visuals.Append(new LoadoutConfig_Visual() { ItemSdbId = sdb_id, VisualType = visual, Data1 = 0, Data2 = 0, Transform = Array.Empty<float>() }).ToArray();
             var item = _items.First(e => e.Value.SdbId == sdb_id).Value;
         }
 

--- a/UdpHosts/GameServer/Enums/Operand.cs
+++ b/UdpHosts/GameServer/Enums/Operand.cs
@@ -2,13 +2,18 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace GameServer.Enums;
 
-[SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1602:EnumerationItemsMustBeDocumented", Justification = "TODO")]
+[SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1602:EnumerationItemsMustBeDocumented", Justification = "Based on FUN_00bc1130")]
 public enum Operand : byte
 {
     ASSIGN = 0,
-    ADDITIVE = 1,
-    MULTIPLICATIVE = 2,
-    PERK_DAMAGE_SCALAR = 3, // Uncertain
-    DIVIDE_FIRST_BY_SECOND = 4, // Uncertain
-    DIVIDE_SECOND_BY_FIRST = 5, // Uncertain
+    ADD = 1,
+    MULTIPLY = 2,
+    EXPONENTIATE = 3,
+    SUBTRACT = 4,
+    DIVIDE = 5,
+    // Add and multiply appear twice in a switch inside client
+    ADD_ALT = 6,
+    MULTIPLY_ALT = 7,
+    MINIMUM = 8,
+    MAXIMUM = 9,
 }

--- a/UdpHosts/GameServer/Enums/Operand.cs
+++ b/UdpHosts/GameServer/Enums/Operand.cs
@@ -5,13 +5,13 @@ namespace GameServer.Enums;
 [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1602:EnumerationItemsMustBeDocumented", Justification = "Based on FUN_00bc1130")]
 public enum Operand : byte
 {
+    // Add and multiply appear twice in a switch inside client
     ASSIGN = 0,
     ADD = 1,
     MULTIPLY = 2,
     EXPONENTIATE = 3,
     SUBTRACT = 4,
     DIVIDE = 5,
-    // Add and multiply appear twice in a switch inside client
     ADD_ALT = 6,
     MULTIPLY_ALT = 7,
     MINIMUM = 8,

--- a/UdpHosts/GameServer/StaticDB/Loaders/StaticDBLoader.cs
+++ b/UdpHosts/GameServer/StaticDB/Loaders/StaticDBLoader.cs
@@ -128,6 +128,12 @@ public class StaticDBLoader : ISDBLoader
         .ToDictionary(row => row.Id);
     }
 
+    public Dictionary<uint, ImpactToggleEffectCommandDef> LoadImpactToggleEffectCommandDef()
+    {
+        return LoadStaticDB<ImpactToggleEffectCommandDef>("apt::ImpactToggleEffectCommandDef")
+            .ToDictionary(row => row.Id);
+    }
+
     public Dictionary<uint, ConditionalBranchCommandDef> LoadConditionalBranchCommandDef()
     {
         return LoadStaticDB<ConditionalBranchCommandDef>("apt::ConditionalBranchCommandDef")

--- a/UdpHosts/GameServer/StaticDB/SDBInterface.cs
+++ b/UdpHosts/GameServer/StaticDB/SDBInterface.cs
@@ -259,6 +259,7 @@ public class SDBInterface
         CommandType = loader.LoadCommandType();
         AbilityData = loader.LoadAbilityData();
         ImpactApplyEffectCommandDef = loader.LoadImpactApplyEffectCommandDef();
+        ImpactToggleEffectCommandDef = loader.LoadImpactToggleEffectCommandDef();
         WhileLoopCommandDef = loader.LoadWhileLoopCommandDef();
         LogicNegateCommandDef = loader.LoadLogicNegateCommandDef();
         LogicOrCommandDef = loader.LoadLogicOrCommandDef();

--- a/UdpHosts/GameServer/Systems/Aptitude/AbilitySystem.cs
+++ b/UdpHosts/GameServer/Systems/Aptitude/AbilitySystem.cs
@@ -33,19 +33,27 @@ public class AbilitySystem
         {
             case Operand.ASSIGN:
                 return second;
-            case Operand.ADDITIVE:
-                return first + second;
-            case Operand.MULTIPLICATIVE:
-                return first * second;
-            case Operand.PERK_DAMAGE_SCALAR:
-                Console.WriteLine($"Uncertain RegistryOp {op}");
-                return first * second; // TODO: Uncertain
-            case Operand.DIVIDE_FIRST_BY_SECOND:
-                Console.WriteLine($"Uncertain RegistryOp {op}");
-                return first / second;
-            case Operand.DIVIDE_SECOND_BY_FIRST:
-                Console.WriteLine($"Uncertain RegistryOp {op}");
+            case Operand.ADD:
+            case Operand.ADD_ALT:
+                return second + first;
+            case Operand.MULTIPLY:
+            case Operand.MULTIPLY_ALT:
+                return second * first;
+            case Operand.EXPONENTIATE:
+                Console.WriteLine($"Uncertain RegistryOp {op}. {second} ^ {first} = {(float)Math.Pow(second, first)}");
+                return (float)Math.Pow(second, first);
+            case Operand.SUBTRACT:
+                Console.WriteLine($"Uncertain RegistryOp {op}. {second} - {first} = {second - first}");
+                return second - first;
+            case Operand.DIVIDE:
+                Console.WriteLine($"Uncertain RegistryOp {op}. {second} / {first} = {second / first}");
                 return second / first;
+            case Operand.MINIMUM:
+                Console.WriteLine($"Uncertain RegistryOp {op}. Min({second}, {first}) = {((first <= second) ? first : second)}");
+                return (first <= second) ? first : second;
+            case Operand.MAXIMUM:
+                Console.WriteLine($"Uncertain RegistryOp {op}. Max({second}, {first}) = {((first >= second) ? first : second)}");
+                return (first >= second) ? first : second;
             default:
                 Console.WriteLine($"Unknown RegistryOp {op}");
                 return second;


### PR DESCRIPTION
Added possible remaining `Operand` enum values and cases to `RegistryOp` method 
based on functions at addresses `00bc1130`, `00bc1020`, `00bc0770`, `00eb2030`.
They seem to be used in most of aptitude commands having `regop` fields e.g. 
`TargetByHealth`, `InflictCooldown`, `HealDamage`, `TargetFilterByRange`, `RequireEnergy`, 
`MovementTether`, `MovementSlide`, all `RegisterLoadFrom` types of commands etc.
I'm not sure about `ForcePush`, `AddPhysics`, `ConsumeSuperCharge`.

Most of command instances use regops 0, 1 or 2 and meaning of these 
remains unchanged - assignment, addition, multiplication.

Gist file that shows count of each regop value, for all `client` and `both` env commands 
is available at https://gist.github.com/SzymonKaminski/e9989bed76ba1dad6c2ede6c09736098.