### PR TITLE
Execute updateChains, use updateFreq for durations too

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ https://user-images.githubusercontent.com/920861/134824107-03e9f99c-b420-47c7-b7
 
 **Note:** If you want to play around with the configuration, see the Development section below
 
-1. [Install Firefall via Steam](steam://install/227700)
+1. Install Firefall via Steam (paste `steam://install/227700` into address bar of web browser)
 2. Edit the `firefall.ini` located in `steamapps\common\Firefall`
 3. Add content from below
 4. Download the [latest PIN release](https://github.com/themeldingwars/PIN/releases/latest)

--- a/UdpHosts/GameServer/Entities/BaseAptitudeEntity.cs
+++ b/UdpHosts/GameServer/Entities/BaseAptitudeEntity.cs
@@ -47,10 +47,13 @@ public abstract class BaseAptitudeEntity : BaseEntity, IAptitudeTarget
             
             if (ActiveEffects[i]?.Effect.Id == effect.Id)
             {
-                // TODO: What to do?
                 if (ActiveEffects[i].Stacks < effect.MaxStackCount)
                 { 
                     ActiveEffects[i].Stacks += 1;
+                }
+                else
+                {
+                    return new EffectState() { MaxStacksExceeded = true };
                 }
 
                 return ActiveEffects[i];

--- a/UdpHosts/GameServer/StaticDB/CustomData/aptgss_agsImpactRemoveEffectCommandDef.json
+++ b/UdpHosts/GameServer/StaticDB/CustomData/aptgss_agsImpactRemoveEffectCommandDef.json
@@ -1985,7 +1985,9 @@
 	},
 	{
 		"id": 271326,
-		"comment": "Triggered by Effect 2688  "
+		"comment": "Triggered by Effect 2688  ",
+		"effect_id": 2768,
+		"remove_from_self": true
 	},
 	{
 		"id": 271413,

--- a/UdpHosts/GameServer/Systems/Aptitude/Chain.cs
+++ b/UdpHosts/GameServer/Systems/Aptitude/Chain.cs
@@ -22,9 +22,9 @@ public class Chain
         OrChain
     }
 
-    public bool Execute(Context context, ExecutionMethod method = ExecutionMethod.AndChain) 
+    public bool Execute(Context context, ExecutionMethod method = ExecutionMethod.AndChain)
     {
-        bool debug = context.ExecutionHint != ExecutionHint.DurationEffect;
+        bool debug = context.ExecutionHint is not(ExecutionHint.DurationEffect or ExecutionHint.UpdateEffect);
 
         if (debug)
         {

--- a/UdpHosts/GameServer/Systems/Aptitude/Commands/Requirement/RequireMovingCommand.cs
+++ b/UdpHosts/GameServer/Systems/Aptitude/Commands/Requirement/RequireMovingCommand.cs
@@ -23,9 +23,18 @@ public class RequireMovingCommand : Command, ICommand
         
         if (target is CharacterEntity character)
         {
-            result = character.MovementStateContainer.Movement;
-
-            // Params.Velocitytol // velocity tolerance
+            if (Params.CheckVelocity == 1)
+            {
+                if (Params.Velocitytol == 0)
+                {
+                    result = !character.MovementStateContainer.Movement;
+                }
+                else
+                {
+                    // todo
+                    Console.WriteLine($"[RequireMovingCommand] velocity tolerance: {Params.Velocitytol}, negate: {Params.Negate}");
+                }
+            }
         }
         else
         {

--- a/UdpHosts/GameServer/Systems/Aptitude/Commands/Target/PushTargetsCommand.cs
+++ b/UdpHosts/GameServer/Systems/Aptitude/Commands/Target/PushTargetsCommand.cs
@@ -15,12 +15,12 @@ public class PushTargetsCommand : Command, ICommand
     public bool Execute(Context context)
     {
         // todo aptitude: verify what to push
-        if (Params.Former == 1)
+        if (Params.Former == 1 && context.FormerTargets.Count > 0)
         {
             context.FormerTargets.Push(context.Targets.Peek());
         }
 
-        if (Params.Current == 1)
+        if (Params.Current == 1 && context.Targets.Count > 0)
         {
             context.Targets.Push(context.Targets.Peek());
         }

--- a/UdpHosts/GameServer/Systems/Aptitude/Commands/Target/TargetPBAECommand.cs
+++ b/UdpHosts/GameServer/Systems/Aptitude/Commands/Target/TargetPBAECommand.cs
@@ -64,7 +64,7 @@ public class TargetPBAECommand : Command, ICommand
                     return false;
                 }
 
-                var distance = Vector3.DistanceSquared(origin, compatibleEntity.Position);
+                var distance = Vector3.Distance(origin, compatibleEntity.Position);
                 if (distance <= radius)
                 {
                     return true;

--- a/UdpHosts/GameServer/Systems/Aptitude/EffectState.cs
+++ b/UdpHosts/GameServer/Systems/Aptitude/EffectState.cs
@@ -6,5 +6,7 @@ public class EffectState
     public Context Context;
     public byte Index = 0;
     public uint Time;
+    public ulong LastUpdateTime = 0;
     public byte Stacks = 1;
+    public bool MaxStacksExceeded = false;
 }

--- a/UdpHosts/GameServer/Systems/EntityManager/EntityManager.cs
+++ b/UdpHosts/GameServer/Systems/EntityManager/EntityManager.cs
@@ -30,6 +30,7 @@ using GameServer.Entities.Turret;
 using GameServer.Entities.Vehicle;
 using GameServer.Enums.GSS;
 using GameServer.Extensions;
+using Timer = System.Threading.Timer;
 
 namespace GameServer;
 
@@ -165,17 +166,13 @@ public class EntityManager
 
         if (deployableInfo.ConstructedAbilityid != 0)
         {
-            new System.Threading.Timer(state =>
-            {
-                Shard.Abilities.HandleActivateAbility(Shard, deployableEntity, deployableInfo.ConstructedAbilityid, Shard.CurrentTime, new AptitudeTargets());
-                if (state != null)
-                {
-                    ((System.Threading.Timer)state).Dispose();
-                }
-            },
-            null,
-            deployableInfo.BuildTimeMs,
-            Timeout.Infinite);
+            var timer = new Timer(state =>
+                 {
+                     Shard.Abilities.HandleActivateAbility(Shard, deployableEntity, deployableInfo.ConstructedAbilityid, Shard.CurrentTime, new AptitudeTargets());
+
+                     ((Timer)state)?.Dispose();
+                 });
+            timer.Change(deployableInfo.BuildTimeMs, Timeout.Infinite);
         }
 
         if (deployableInfo.TurretType != 0)
@@ -196,18 +193,14 @@ public class EntityManager
                 }
             }
 
-            new System.Threading.Timer(state =>
-            {
-                Console.WriteLine($"deployable: Executing ability {deployableInfo.PoweredOnAbility}");
-                Shard.Abilities.HandleActivateAbility(Shard, deployableEntity, poweredOnAbility, Shard.CurrentTime, new AptitudeTargets());
-                if (state != null)
-                {
-                    ((System.Threading.Timer)state).Dispose();
-                }
-            },
-            null,
-            deployableInfo.BuildTimeMs,
-            Timeout.Infinite);
+            var timer = new Timer(state =>
+                 {
+                     Console.WriteLine($"deployable: Executing ability {deployableInfo.PoweredOnAbility}");
+                     Shard.Abilities.HandleActivateAbility(Shard, deployableEntity, poweredOnAbility, Shard.CurrentTime, new AptitudeTargets());
+
+                     ((Timer)state)?.Dispose();
+                 });
+            timer.Change(deployableInfo.BuildTimeMs, Timeout.Infinite);
         }
 
         return deployableEntity;


### PR DESCRIPTION
Added execution of update chain during processing of targets, if duration chain hasn't removed given effect yet. Used updateFrequency for both as there are 6373 status effects with `update_chain = 0 and update_frequency != 0 and duration_chain != 0`.