### PR TITLE
Update CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,4 @@ jobs:
         with:
           name: PIN-${{ github.sha }}
           path: Publish
+          include-hidden-files: true

--- a/WebHosts/WebHostManager/WebHostManager.csproj
+++ b/WebHosts/WebHostManager/WebHostManager.csproj
@@ -24,6 +24,7 @@
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
         <PackageReference Include="Serilog.AspNetCore" Version="8.0.2" />
+        <PackageReference Include="Serilog.Settings.AppSettings" Version="3.0.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
         <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
     </ItemGroup>


### PR DESCRIPTION
Noticed WebHostManager from artifact is not starting properly when all projects are outputted to same directory and Assets dir was missing as it only contains .gitkeep.