### PR TITLE
Target .NET 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
       matrix:
         platform:
           - { name: Linux, os: ubuntu-24.04 }
-          - { name: Windows VS2022, os: windows-2022 }
-          - { name: macOS, os: macos-14 }
+          - { name: Windows, os: windows-2025 }
+          - { name: macOS, os: macos-15 }
         dotnet:
           - { name: .NET 8, version: "8.0.x" }
           - { name: .NET 9, version: "9.0.x" }
@@ -24,12 +24,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Setup .NET ${{ matrix.dotnet.version }} SDK
         id: setup-dotnet
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ matrix.dotnet.version }}
       - name: Enforce SDK Version
@@ -42,15 +42,15 @@ jobs:
       - name: Build
         run: dotnet build --configuration Release --no-restore
       - name: Publish
-        if: matrix.platform.name == 'Windows VS2022' && matrix.dotnet.name == '.NET 8'
+        if: matrix.platform.name == 'Windows' && matrix.dotnet.name == '.NET 10'
         run: |
           dotnet publish --runtime win-x64 --no-self-contained --configuration Release -p:DebugType=None -p:DebugSymbols=false -p:PublishReadyToRun=true -p:IncludeNativeLibrariesForSelfExtract=true -o Publish
           cp ./Start.cmd ./Publish
           cp ./README.md ./Publish
           cp ./CHANGELOG.md ./Publish
       - name: Upload Artifact
-        if: matrix.platform.name == 'Windows VS2022' && matrix.dotnet.name == '.NET 8'
-        uses: actions/upload-artifact@v4
+        if: matrix.platform.name == 'Windows' && matrix.dotnet.name == '.NET 10'
+        uses: actions/upload-artifact@v6
         with:
           name: PIN-${{ github.sha }}
           path: Publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,8 @@ jobs:
           - { name: Windows, os: windows-2025 }
           - { name: macOS, os: macos-15 }
         dotnet:
-          - { name: .NET 8, version: "8.0.x" }
-          - { name: .NET 9, version: "9.0.x" }
           - { name: .NET 10, version: "10.0.x" }
+          - { name: .NET 11, version: "11.0.x" }
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
         dotnet:
           - { name: .NET 8, version: "8.0.x" }
           - { name: .NET 9, version: "9.0.x" }
+          - { name: .NET 10, version: "10.0.x" }
 
     steps:
       - name: Checkout

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <PropertyGroup Condition="'$(MSBuildProjectName)' != 'AeroMessages' And
@@ -14,7 +14,7 @@
     <PropertyGroup>
         <Version>1.2.0</Version>
         <Company>The Melding Wars</Company>
-        <Copyright>Copyright © 2019-2025 by The Melding Wars</Copyright>
+        <Copyright>Copyright © 2019-2026 by The Melding Wars</Copyright>
         <Product>Pirate Intelligence Network</Product>
     </PropertyGroup>
 </Project>

--- a/Lib/Core.Data/Core.Data.csproj
+++ b/Lib/Core.Data/Core.Data.csproj
@@ -1,7 +1,2 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
-    <ItemGroup>
-        <PackageReference Include="System.Data.Common" Version="4.3.0"/>
-    </ItemGroup>
-
 </Project>

--- a/Lib/Shared.Common/Shared.Common.csproj
+++ b/Lib/Shared.Common/Shared.Common.csproj
@@ -1,10 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
         <PackageReference Include="Serilog" Version="4.3.1" />
         <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
-        <PackageReference Include="System.Text.Json" Version="10.0.5" />
     </ItemGroup>
 
 </Project>

--- a/Lib/Shared.Common/Shared.Common.csproj
+++ b/Lib/Shared.Common/Shared.Common.csproj
@@ -2,9 +2,9 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
-        <PackageReference Include="Serilog" Version="4.3.0" />
-        <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
-        <PackageReference Include="System.Text.Json" Version="8.0.5" />
+        <PackageReference Include="Serilog" Version="4.3.1" />
+        <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
+        <PackageReference Include="System.Text.Json" Version="10.0.5" />
     </ItemGroup>
 
 </Project>

--- a/Lib/Shared.Udp/Shared.Udp.csproj
+++ b/Lib/Shared.Udp/Shared.Udp.csproj
@@ -6,8 +6,6 @@
 
     <ItemGroup>
         <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
-        <PackageReference Include="System.Net.Sockets" Version="4.3.0"/>
-        <PackageReference Include="System.Threading.Tasks.Dataflow" Version="10.0.5" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Lib/Shared.Udp/Shared.Udp.csproj
+++ b/Lib/Shared.Udp/Shared.Udp.csproj
@@ -5,9 +5,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+        <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
         <PackageReference Include="System.Net.Sockets" Version="4.3.0"/>
-        <PackageReference Include="System.Threading.Tasks.Dataflow" Version="8.0.1" />
+        <PackageReference Include="System.Threading.Tasks.Dataflow" Version="10.0.5" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Lib/Shared.Web/Shared.Web.csproj
+++ b/Lib/Shared.Web/Shared.Web.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-        <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
-        <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="8.1.1" />
-        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="8.1.1" />
-        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="8.1.1" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+        <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="10.1.7" />
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.1.7" />
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.7" />
     </ItemGroup>
 
     <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ https://user-images.githubusercontent.com/920861/134824107-03e9f99c-b420-47c7-b7
 4. Download the [latest PIN release](https://github.com/themeldingwars/PIN/releases/latest)
 5. Make a backup copy of the original `FirefallClient.exe` in `Firefall\system\bin`
 6. Replace the `FirefallClient.exe` with the patched `FirefallClient.exe` from the PIN release
-7. Make sure the [.NET 8 Runtime](https://dotnet.microsoft.com/download/dotnet/8.0) is installed
+7. Make sure the [.NET 10 Runtime](https://dotnet.microsoft.com/download/dotnet/10.0) is installed
 8. Trust self-signed development certificates by running `dotnet dev-certs https --trust`
 9. Start all three applications:
    - GameServer
@@ -63,10 +63,10 @@ PlayIntroMovie = false
 ## Development
 
 1. Install Visual Studio or JetBrains Rider
-   - Include the [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0) component or install it separately
+   - Include the [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) component or install it separately
 2. Recursive clone the repository `git clone --recurse-submodules https://github.com/themeldingwars/PIN.git`
 3. Build the solution
-4. Edit the `GameServer.dll.config` produced by the build in `UdpHosts\GameServer\bin\Release\net8.0` to ensure that `StaticDBPath` is correct.
+4. Edit the `GameServer.dll.config` produced by the build in `UdpHosts\GameServer\bin\Release\net10.0` to ensure that `StaticDBPath` is correct.
 5. Trust self-signed development certificates by running `dotnet dev-certs https --trust`
 6. Start multiple targets at once
    - Visual Studio: Create a `Multiple Startup Projects` target that start WebHostManager, GameServer and MatrixServer

--- a/UdpHosts/GameServer/GameServer.csproj
+++ b/UdpHosts/GameServer/GameServer.csproj
@@ -15,12 +15,12 @@
     </PackageReference>
     <PackageReference Include="Serilog.Enrichers.Context" Version="4.6.5" />
     <PackageReference Include="Serilog.Settings.AppSettings" Version="3.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="Serilog.Sinks.Map" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="9.0.0" />
-    <PackageReference Include="System.IO.Hashing" Version="8.0.0" />
-    <PackageReference Include="System.IO.Pipelines" Version="8.0.0" />
+    <PackageReference Include="System.IO.Hashing" Version="10.0.5" />
+    <PackageReference Include="System.IO.Pipelines" Version="10.0.5" />
     <PackageReference Include="FauFau" Version="1.5.0" />
   </ItemGroup>
   <ItemGroup>

--- a/UdpHosts/GameServer/GameServer.csproj
+++ b/UdpHosts/GameServer/GameServer.csproj
@@ -5,11 +5,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Aero.Gen" Version="1.3.3" />
-    <PackageReference Include="Autofac" Version="8.3.0" />
+    <PackageReference Include="Autofac" Version="9.1.0" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Google.Protobuf" Version="3.25.6" />
-    <PackageReference Include="Grpc.Net.Client" Version="2.60.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.60.0">
+    <PackageReference Include="Google.Protobuf" Version="3.34.1" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.76.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.76.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -21,7 +21,7 @@
     <PackageReference Include="Serilog.Sinks.Seq" Version="9.0.0" />
     <PackageReference Include="System.IO.Hashing" Version="8.0.0" />
     <PackageReference Include="System.IO.Pipelines" Version="8.0.0" />
-    <PackageReference Include="FauFau" Version="1.3.0" />
+    <PackageReference Include="FauFau" Version="1.5.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Lib\AeroMessages\AeroMessages\AeroMessages.csproj" />

--- a/UdpHosts/GameServer/GameServer.csproj
+++ b/UdpHosts/GameServer/GameServer.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="Serilog.Sinks.Map" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="9.0.0" />
     <PackageReference Include="System.IO.Hashing" Version="10.0.5" />
-    <PackageReference Include="System.IO.Pipelines" Version="10.0.5" />
     <PackageReference Include="FauFau" Version="1.5.0" />
   </ItemGroup>
   <ItemGroup>

--- a/UdpHosts/GameServer/Systems/Aptitude/Commands/Register/LoadRegisterFromItemStatCommand.cs
+++ b/UdpHosts/GameServer/Systems/Aptitude/Commands/Register/LoadRegisterFromItemStatCommand.cs
@@ -3,7 +3,6 @@ using GameServer.Data.SDB;
 using GameServer.Data.SDB.Records.apt;
 using GameServer.Entities.Character;
 using GameServer.Enums;
-using SharpCompress;
 
 namespace GameServer.Aptitude;
 
@@ -52,7 +51,7 @@ public class LoadRegisterFromItemStatCommand : Command, ICommand
         if (true)
         {
             var statInfo = SDBInterface.GetAttributeDefinition((uint)Params.Stat);
-            Logger.Debug("{Command} {CommandId}: ({prevValue}, {statValue} ({statName}), {op}) => {register}", nameof(LoadRegisterFromItemStatCommand), Params.Id, prevValue, statValue, statInfo.Name.TrimNulls(), (Operand)Params.Regop, context.Register);
+            Logger.Debug("{Command} {CommandId}: ({prevValue}, {statValue} ({statName}), {op}) => {register}", nameof(LoadRegisterFromItemStatCommand), Params.Id, prevValue, statValue, statInfo.Name.Trim(), (Operand)Params.Regop, context.Register);
         }
 
         return true;

--- a/UdpHosts/MatrixServer/MatrixServer.csproj
+++ b/UdpHosts/MatrixServer/MatrixServer.csproj
@@ -6,10 +6,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Autofac" Version="8.3.0" />
+        <PackageReference Include="Autofac" Version="9.1.0" />
         <PackageReference Include="CommandLineParser" Version="2.9.1" />
         <PackageReference Include="Serilog.Settings.AppSettings" Version="3.0.0" />
-        <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+        <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/WebHosts/WebHost.Chat/WebHost.Chat.csproj
+++ b/WebHosts/WebHost.Chat/WebHost.Chat.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-        <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+        <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/WebHosts/WebHostManager/WebHostManager.csproj
+++ b/WebHosts/WebHostManager/WebHostManager.csproj
@@ -19,11 +19,11 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
-        <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.5" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.5" />
+        <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
         <PackageReference Include="Serilog.Settings.AppSettings" Version="3.0.0" />
-        <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+        <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
         <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
     </ItemGroup>
 


### PR DESCRIPTION
- Sets the target framework to .NET 10
- Updates ci workflow to build for 10 and 11, and aligns platform versions with current FauFau workflow
- Broadly updates dependencies to the latest stable versions.
- Pruned dependencies that [didn't have to be specified anymore](https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/10.0/nu1510-pruned-references).