### PR TITLE
Add more tables to SDB Interface

### DIFF
--- a/UdpHosts/GameServer/StaticDB/Loaders/ISDBLoader.cs
+++ b/UdpHosts/GameServer/StaticDB/Loaders/ISDBLoader.cs
@@ -4,8 +4,10 @@ using System.Collections.Generic;
 using Records.apt;
 using Records.aptfs;
 using Records.dbcharacter;
+using Records.dbencounterdata;
 using Records.dbitems;
-using Records.dbviusalrecords;
+using Records.dbvisualrecords;
+using Records.dbzonemetadata;
 using Records.vcs;
 
 public interface ISDBLoader
@@ -14,8 +16,15 @@ public interface ISDBLoader
     Dictionary<uint, CharCreateLoadout> LoadCharCreateLoadout();
     Dictionary<uint, Dictionary<byte, CharCreateLoadoutSlots>> LoadCharCreateLoadoutSlots();
     Dictionary<uint, Deployable> LoadDeployable();
+    Dictionary<uint, DeployableFunction> LoadDeployableFunction();
+    Dictionary<uint, DeployableCategory> LoadDeployableCategory();
+    Dictionary<uint, Faction> LoadFaction();
     Dictionary<uint, Monster> LoadMonster();
     Dictionary<uint, Turret> LoadTurret();
+
+    // dbencounterdata
+    Dictionary<uint, MapMarkerInfo> LoadMapMarkerInfo();
+    Dictionary<uint, SinCardTemplate> LoadSinCardTemplate();
 
     // dbvisualrecords
     Dictionary<uint, WarpaintPalette> LoadWarpaintPalettes();
@@ -35,11 +44,21 @@ public interface ISDBLoader
     Dictionary<uint, WeaponScope> LoadWeaponScope();
     Dictionary<uint, WeaponUnderbarrel> LoadWeaponUnderbarrel();
     Dictionary<uint, Ammo> LoadAmmo();
+    Dictionary<uint, LevelBand> LoadLevelBand();
+    Dictionary<uint, ResourceNodeBeacon> LoadResourceNodeBeacon();
+    Dictionary<KeyValuePair<uint, uint>, LevelCategoryScalars> LoadLevelCategoryScalars();
+    Dictionary<uint, FrameProgressionLevel> LoadFrameProgressionLevel();
+    Dictionary<uint, Blueprints> LoadBlueprints();
+    Dictionary<uint, List<Blueprint_Items>> LoadBlueprintItems();
+
+    // dbzonemetadata
+    Dictionary<uint, ZoneRecord> LoadZoneRecord();
 
     // apt
     Dictionary<uint, BaseCommandDef> LoadBaseCommandDef();
     Dictionary<uint, CommandType> LoadCommandType();
     Dictionary<uint, AbilityData> LoadAbilityData();
+    Dictionary<uint, ActiveInitiationCommandDef> LoadActiveInitiationCommandDef();
     Dictionary<uint, ImpactApplyEffectCommandDef> LoadImpactApplyEffectCommandDef();
     Dictionary<uint, ConditionalBranchCommandDef> LoadConditionalBranchCommandDef();
     Dictionary<uint, WhileLoopCommandDef> LoadWhileLoopCommandDef();
@@ -51,6 +70,7 @@ public interface ISDBLoader
     Dictionary<uint, InstantActivationCommandDef> LoadInstantActivationCommandDef();
     Dictionary<uint, StagedActivationCommandDef> LoadStagedActivationCommandDef();
     Dictionary<uint, StatusEffectData> LoadStatusEffectData();
+    Dictionary<uint, HashSet<uint>> LoadStatusEffectTags();
     Dictionary<uint, TargetPBAECommandDef> LoadTargetPBAECommandDef();
     Dictionary<uint, TargetConeAECommandDef> LoadTargetConeAECommandDef();
     Dictionary<uint, TargetClearCommandDef> LoadTargetClearCommandDef();

--- a/UdpHosts/GameServer/StaticDB/Loaders/ISDBLoader.cs
+++ b/UdpHosts/GameServer/StaticDB/Loaders/ISDBLoader.cs
@@ -6,6 +6,7 @@ using Records.aptfs;
 using Records.dbcharacter;
 using Records.dbencounterdata;
 using Records.dbitems;
+using Records.dbphysicsmaterials;
 using Records.dbvisualrecords;
 using Records.dbzonemetadata;
 using Records.vcs;
@@ -19,15 +20,27 @@ public interface ISDBLoader
     Dictionary<uint, DeployableFunction> LoadDeployableFunction();
     Dictionary<uint, DeployableCategory> LoadDeployableCategory();
     Dictionary<uint, Faction> LoadFaction();
+    List<FactionRelations> LoadFactionRelations();
+    Dictionary<uint, List<FactionReputations>> LoadFactionReputations();
     Dictionary<uint, Monster> LoadMonster();
     Dictionary<uint, Turret> LoadTurret();
+    Dictionary<uint, PoseType> LoadPoseType();
+    Dictionary<uint, CharInfo> LoadCharInfo();
+    Dictionary<byte, DamageType> LoadDamageType();
+    Dictionary<byte, DamageResponse> LoadDamageResponse();
+    Dictionary<uint, DamageResponseDamageType> LoadDamageResponseDamageType();
+    Dictionary<uint, TinyObject> LoadTinyObject();
 
     // dbencounterdata
     Dictionary<uint, MapMarkerInfo> LoadMapMarkerInfo();
     Dictionary<uint, SinCardTemplate> LoadSinCardTemplate();
 
+    // dbphysicsmaterials
+    Dictionary<uint, PhysicsMaterial> LoadPhysicsMaterial();
+
     // dbvisualrecords
     Dictionary<uint, WarpaintPalette> LoadWarpaintPalettes();
+    Dictionary<uint, VisualRecord> LoadVisualRecord();
 
     // dbitems
     Dictionary<uint, AttributeCategory> LoadAttributeCategory();
@@ -50,6 +63,7 @@ public interface ISDBLoader
     Dictionary<uint, FrameProgressionLevel> LoadFrameProgressionLevel();
     Dictionary<uint, Blueprints> LoadBlueprints();
     Dictionary<uint, List<Blueprint_Items>> LoadBlueprintItems();
+    Dictionary<uint, List<BattleframeVisuals>> LoadBattleframeVisuals();
 
     // dbzonemetadata
     Dictionary<uint, ZoneRecord> LoadZoneRecord();
@@ -250,4 +264,5 @@ public interface ISDBLoader
     Dictionary<uint, TurretComponentDef> LoadTurretComponentDef();
     Dictionary<uint, DeployableComponentDef> LoadDeployableComponentDef();
     Dictionary<uint, SpawnPointComponentDef> LoadSpawnPointComponentDef();
+    Dictionary<uint, HullSegmentDef> LoadHullSegmentDef();
 }

--- a/UdpHosts/GameServer/StaticDB/Loaders/StaticDBLoader.cs
+++ b/UdpHosts/GameServer/StaticDB/Loaders/StaticDBLoader.cs
@@ -1502,7 +1502,17 @@ public class StaticDBLoader : ISDBLoader
                 {
                     if (prop.Index != -1)
                     {
-                        prop.PropInfo.SetValue(entry, row[prop.Index], null);
+                        if (prop.PropInfo.PropertyType == typeof(string))
+                        {
+                            // FauFau SDB parser leaves null characters in strings, which can break things for us if we try to send one of these strings in a network message, so let's make sure that can't happen.
+                            string rawStr = (string)row[prop.Index];
+                            string cleanStr = rawStr.Replace("\0", string.Empty);
+                            prop.PropInfo.SetValue(entry, cleanStr, null);
+                        }
+                        else
+                        {
+                            prop.PropInfo.SetValue(entry, row[prop.Index], null);
+                        }
                     }
                     else
                     {

--- a/UdpHosts/GameServer/StaticDB/Loaders/StaticDBLoader.cs
+++ b/UdpHosts/GameServer/StaticDB/Loaders/StaticDBLoader.cs
@@ -7,8 +7,10 @@ using FauFau.Formats;
 using Records.apt;
 using Records.aptfs;
 using Records.dbcharacter;
+using Records.dbencounterdata;
 using Records.dbitems;
-using Records.dbviusalrecords;
+using Records.dbvisualrecords;
+using Records.dbzonemetadata;
 using Records.vcs;
 using Serilog;
 using Shared.Common;
@@ -51,6 +53,24 @@ public class StaticDBLoader : ISDBLoader
         .ToDictionary(row => row.Id);
     }
 
+    public Dictionary<uint, DeployableFunction> LoadDeployableFunction()
+    {
+        return LoadStaticDB<DeployableFunction>("dbcharacter::DeployableFunction")
+            .ToDictionary(row => row.Id);
+    }
+
+    public Dictionary<uint, DeployableCategory> LoadDeployableCategory()
+    {
+        return LoadStaticDB<DeployableCategory>("dbcharacter::DeployableCategory")
+            .ToDictionary(row => row.Id);
+    }
+
+    public Dictionary<uint, Faction> LoadFaction()
+    {
+        return LoadStaticDB<Faction>("dbcharacter::Faction")
+            .ToDictionary(row => row.Id);
+    }
+
     public Dictionary<uint, Monster> LoadMonster()
     {
         return LoadStaticDB<Monster>("dbcharacter::Monster")
@@ -60,6 +80,18 @@ public class StaticDBLoader : ISDBLoader
     public Dictionary<uint, Turret> LoadTurret()
     {
         return LoadStaticDB<Turret>("dbcharacter::Turret")
+            .ToDictionary(row => row.Id);
+    }
+
+    public Dictionary<uint, MapMarkerInfo> LoadMapMarkerInfo()
+    {
+        return LoadStaticDB<MapMarkerInfo>("dbencounterdata::MapMarkerInfo")
+            .ToDictionary(row => row.Id);
+    }
+
+    public Dictionary<uint, SinCardTemplate> LoadSinCardTemplate()
+    {
+        return LoadStaticDB<SinCardTemplate>("dbencounterdata::SinCardTemplate")
             .ToDictionary(row => row.Id);
     }
 
@@ -140,6 +172,12 @@ public class StaticDBLoader : ISDBLoader
     public Dictionary<uint, AbilityData> LoadAbilityData()
     {
         return LoadStaticDB<AbilityData>("apt::AbilityData")
+        .ToDictionary(row => row.Id);
+    }
+
+    public Dictionary<uint, ActiveInitiationCommandDef> LoadActiveInitiationCommandDef()
+    {
+        return LoadStaticDB<ActiveInitiationCommandDef>("apt::ActiveInitiationCommandDef")
         .ToDictionary(row => row.Id);
     }
 
@@ -1309,10 +1347,49 @@ public class StaticDBLoader : ISDBLoader
             .ToDictionary(row => row.Id);
     }
 
+    public Dictionary<uint, LevelBand> LoadLevelBand()
+    {
+        return LoadStaticDB<LevelBand>("dbitems::LevelBand")
+            .ToDictionary(row => row.Id);
+    }
+
+    public Dictionary<uint, ZoneRecord> LoadZoneRecord()
+    {
+        return LoadStaticDB<ZoneRecord>("dbzonemetadata::ZoneRecord")
+            .ToDictionary(row => row.Id);
+    }
+
     public Dictionary<uint, ResourceNodeBeacon> LoadResourceNodeBeacon()
     {
         return LoadStaticDB<ResourceNodeBeacon>("dbitems::ResourceNodeBeacon")
             .ToDictionary(row => row.Id);
+    }
+
+    public Dictionary<KeyValuePair<uint, uint>, LevelCategoryScalars> LoadLevelCategoryScalars()
+    {
+        return LoadStaticDB<LevelCategoryScalars>("dbitems::LevelCategoryScalars")
+            .GroupBy(row => new KeyValuePair<uint, uint>(row.AttributeCategory, row.Level))
+            .ToDictionary(group => group.Key, group => group.First());
+    }
+
+    public Dictionary<uint, FrameProgressionLevel> LoadFrameProgressionLevel()
+    {
+        return LoadStaticDB<FrameProgressionLevel>("dbitems::FrameProgressionLevel")
+               .GroupBy(row => row.Level)
+               .ToDictionary(group => group.Key, group => group.First());
+    }
+
+    public Dictionary<uint, Blueprints> LoadBlueprints()
+    {
+        return LoadStaticDB<Blueprints>("dbitems::Blueprints")
+            .ToDictionary(row => row.Id);
+    }
+
+    public Dictionary<uint, List<Blueprint_Items>> LoadBlueprintItems()
+    {
+        return LoadStaticDB<Blueprint_Items>("dbitems::Blueprint_Items")
+        .GroupBy(row => row.BlueprintId)
+        .ToDictionary(group => group.Key, group => group.ToList());
     }
 
     private static T[] LoadStaticDB<T>(string tableName)

--- a/UdpHosts/GameServer/StaticDB/Loaders/StaticDBLoader.cs
+++ b/UdpHosts/GameServer/StaticDB/Loaders/StaticDBLoader.cs
@@ -9,6 +9,7 @@ using Records.aptfs;
 using Records.dbcharacter;
 using Records.dbencounterdata;
 using Records.dbitems;
+using Records.dbphysicsmaterials;
 using Records.dbvisualrecords;
 using Records.dbzonemetadata;
 using Records.vcs;
@@ -71,6 +72,19 @@ public class StaticDBLoader : ISDBLoader
             .ToDictionary(row => row.Id);
     }
 
+    public List<FactionRelations> LoadFactionRelations()
+    {
+        return LoadStaticDB<FactionRelations>("dbcharacter::FactionRelations")
+            .ToList();
+    }
+
+    public Dictionary<uint, List<FactionReputations>> LoadFactionReputations()
+    {
+        return LoadStaticDB<FactionReputations>("dbcharacter::FactionReputations")
+        .GroupBy(row => row.FactionId)
+        .ToDictionary(group => group.Key, group => group.ToList());
+    }
+
     public Dictionary<uint, Monster> LoadMonster()
     {
         return LoadStaticDB<Monster>("dbcharacter::Monster")
@@ -98,6 +112,12 @@ public class StaticDBLoader : ISDBLoader
     public Dictionary<uint, WarpaintPalette> LoadWarpaintPalettes() 
     {
         return LoadStaticDB<WarpaintPalette>("dbvisualrecords::WarpaintPalette")
+        .ToDictionary(row => row.Id);
+    }
+
+    public Dictionary<uint, VisualRecord> LoadVisualRecord()
+    {
+        return LoadStaticDB<VisualRecord>("dbvisualrecords::VisualRecord")
         .ToDictionary(row => row.Id);
     }
 
@@ -143,6 +163,13 @@ public class StaticDBLoader : ISDBLoader
     {
         return LoadStaticDB<Battleframe>("dbitems::Battleframe")
         .ToDictionary(row => row.Id);
+    }
+
+    public Dictionary<uint, List<BattleframeVisuals>> LoadBattleframeVisuals()
+    {
+        return LoadStaticDB<BattleframeVisuals>("dbitems::BattleframeVisuals")
+        .GroupBy(row => row.VisualGroup)
+        .ToDictionary(group => group.Key, group => group.ToList());
     }
 
     public Dictionary<uint, AbilityModule> LoadAbilityModule()
@@ -915,6 +942,12 @@ public class StaticDBLoader : ISDBLoader
         .ToDictionary(row => row.Id);
     }
 
+    public Dictionary<uint, HullSegmentDef> LoadHullSegmentDef()
+    {
+        return LoadStaticDB<HullSegmentDef>("vcs::HullSegmentDef")
+        .ToDictionary(row => row.Id);
+    }
+
     public Dictionary<uint, TargetSingleCommandDef> LoadTargetSingleCommandDef()
     {
         return LoadStaticDB<TargetSingleCommandDef>("apt::TargetSingleCommandDef")
@@ -1390,6 +1423,48 @@ public class StaticDBLoader : ISDBLoader
         return LoadStaticDB<Blueprint_Items>("dbitems::Blueprint_Items")
         .GroupBy(row => row.BlueprintId)
         .ToDictionary(group => group.Key, group => group.ToList());
+    }
+
+    public Dictionary<uint, PhysicsMaterial> LoadPhysicsMaterial()
+    {
+        return LoadStaticDB<PhysicsMaterial>("dbphysicsmaterials::PhysicsMaterial")
+            .ToDictionary(row => row.Id);
+    }
+
+    public Dictionary<byte, DamageType> LoadDamageType()
+    {
+        return LoadStaticDB<DamageType>("dbcharacter::DamageType")
+            .ToDictionary(row => row.Id);
+    }
+
+    public Dictionary<byte, DamageResponse> LoadDamageResponse()
+    {
+        return LoadStaticDB<DamageResponse>("dbcharacter::DamageResponse")
+            .ToDictionary(row => row.Id);
+    }
+
+    public Dictionary<uint, DamageResponseDamageType> LoadDamageResponseDamageType()
+    {
+        return LoadStaticDB<DamageResponseDamageType>("dbcharacter::DamageResponseDamageType")
+            .ToDictionary(row => row.Id);
+    }
+
+    public Dictionary<uint, TinyObject> LoadTinyObject()
+    {
+        return LoadStaticDB<TinyObject>("dbcharacter::TinyObject")
+            .ToDictionary(row => row.Id);
+    }
+
+    public Dictionary<uint, PoseType> LoadPoseType()
+    {
+        return LoadStaticDB<PoseType>("dbcharacter::PoseType")
+            .ToDictionary(row => row.PoseId);
+    }
+
+    public Dictionary<uint, CharInfo> LoadCharInfo()
+    {
+        return LoadStaticDB<CharInfo>("dbcharacter::CharInfo")
+            .ToDictionary(row => row.Id);
     }
 
     private static T[] LoadStaticDB<T>(string tableName)

--- a/UdpHosts/GameServer/StaticDB/Records/apt/UpdateWaitAndFireOnceCommandDef.cs
+++ b/UdpHosts/GameServer/StaticDB/Records/apt/UpdateWaitAndFireOnceCommandDef.cs
@@ -2,7 +2,7 @@ namespace GameServer.Data.SDB.Records.apt;
 public record class UpdateWaitAndFireOnceCommandDef : ICommandDef
 {
     public uint Chain { get; set; }
-    public uint Duration { get; set; }    
+    public uint Duration { get; set; }
     public uint Id { get; set; }
     public byte Regop { get; set; }
 }

--- a/UdpHosts/GameServer/StaticDB/Records/dbcharacter/DamageType.cs
+++ b/UdpHosts/GameServer/StaticDB/Records/dbcharacter/DamageType.cs
@@ -1,10 +1,11 @@
 namespace GameServer.Data.SDB.Records.dbcharacter;
+
 public record class DamageType
 {
     public uint LocalizedNameId { get; set; }
     public string Color { get; set; }
     public uint IconAssetId { get; set; }
     public string Name { get; set; }
-    public ushort DamageReduction { get; set; }
+    public ushort DamageReductionAttribute { get; set; }
     public byte Id { get; set; }
 }

--- a/UdpHosts/GameServer/StaticDB/Records/dbcharacter/Faction.cs
+++ b/UdpHosts/GameServer/StaticDB/Records/dbcharacter/Faction.cs
@@ -7,7 +7,7 @@ public record class Faction
     public uint JobBoardIconId { get; set; }
     public uint DescriptionId { get; set; }
     public int MaxReputation { get; set; }
-    public uint AbbreviatedName { get; set; }
+    public uint AbbreviatedNameId { get; set; }
     public int MinReputation { get; set; }
     public uint Id { get; set; }
     public byte DefaultStancePriority { get; set; }

--- a/UdpHosts/GameServer/StaticDB/Records/dbcharacter/TinyObject.cs
+++ b/UdpHosts/GameServer/StaticDB/Records/dbcharacter/TinyObject.cs
@@ -2,11 +2,11 @@ namespace GameServer.Data.SDB.Records.dbcharacter;
 public record class TinyObject
 {
     public float Size { get; set; }
-    public int SpawnPfxId { get; set; }
-    public int PosefileId { get; set; }
-    public int PfxId { get; set; }
-    public int SpawnStatusfxId { get; set; }
-    public int Id { get; set; }
-    public int HitStatusfxId { get; set; }
-    public int Flags { get; set; }
+    public uint SpawnPfxId { get; set; }
+    public uint PosefileId { get; set; }
+    public uint PfxId { get; set; }
+    public uint SpawnStatusfxId { get; set; }
+    public uint Id { get; set; }
+    public uint HitStatusfxId { get; set; }
+    public uint Flags { get; set; }
 }

--- a/UdpHosts/GameServer/StaticDB/Records/dbfabrication/Ingredient.cs
+++ b/UdpHosts/GameServer/StaticDB/Records/dbfabrication/Ingredient.cs
@@ -2,10 +2,10 @@ namespace GameServer.Data.SDB.Records.dbfabrication;
 public record class Ingredient
 {
     public uint IngredientId { get; set; }
-    
+
     public uint IngredientGroupId { get; set; }
-    
+
     public uint ItemId { get; set; }
-    
+
     public uint Id { get; set; }
 }

--- a/UdpHosts/GameServer/StaticDB/Records/dbfabrication/IngredientGroup.cs
+++ b/UdpHosts/GameServer/StaticDB/Records/dbfabrication/IngredientGroup.cs
@@ -2,8 +2,8 @@ namespace GameServer.Data.SDB.Records.dbfabrication;
 public record class IngredientGroup
 {
     public uint NameId { get; set; }
-    
+
     public uint DescriptionId { get; set; }
-    
+
     public uint Id { get; set; }
 }

--- a/UdpHosts/GameServer/StaticDB/Records/dbitems/Backpack.cs
+++ b/UdpHosts/GameServer/StaticDB/Records/dbitems/Backpack.cs
@@ -1,6 +1,6 @@
 namespace GameServer.Data.SDB.Records.dbitems;
 public record class Backpack
-    {
+{
     public uint VisualGroup { get; set; }
     public uint Id { get; set; }
 }

--- a/UdpHosts/GameServer/StaticDB/Records/dbitems/BattleframeVisuals.cs
+++ b/UdpHosts/GameServer/StaticDB/Records/dbitems/BattleframeVisuals.cs
@@ -6,6 +6,6 @@ public record class BattleframeVisuals
     public uint VisualrecId { get; set; }
     public uint VisualGroup { get; set; }
     public uint AnimnetworkId { get; set; }
-    public string Gender { get; set; }
+    public char Gender { get; set; }
     public byte Race { get; set; }
 }

--- a/UdpHosts/GameServer/StaticDB/Records/dbvisualrecords/WarpaintPalette.cs
+++ b/UdpHosts/GameServer/StaticDB/Records/dbvisualrecords/WarpaintPalette.cs
@@ -1,4 +1,4 @@
-namespace GameServer.Data.SDB.Records.dbviusalrecords;
+namespace GameServer.Data.SDB.Records.dbvisualrecords;
 public record class WarpaintPalette
 {
     public uint Id { get; set; }

--- a/UdpHosts/GameServer/StaticDB/Records/vcs/DriverComponentDef.cs
+++ b/UdpHosts/GameServer/StaticDB/Records/vcs/DriverComponentDef.cs
@@ -1,7 +1,10 @@
+using FauFau.Util.CommmonDataTypes;
+
 namespace GameServer.Data.SDB.Records.vcs;
+
 public record class DriverComponentDef
 {
-    // public Vec3 DriverPoseFileOffset { get; set; }
+    public Vector3 DriverPoseFileOffset { get; set; }
     public uint CockpitVisualrec { get; set; }
     public uint DriverPoseFile { get; set; }
     public string Hardpoint { get; set; }

--- a/UdpHosts/GameServer/StaticDB/Records/vcs/PassengerComponentDef.cs
+++ b/UdpHosts/GameServer/StaticDB/Records/vcs/PassengerComponentDef.cs
@@ -1,7 +1,10 @@
+using FauFau.Util.CommmonDataTypes;
+
 namespace GameServer.Data.SDB.Records.vcs;
+
 public record class PassengerComponentDef
 {
-    // public Vec3 PassengerPoseFileOffset { get; set; }
+    public Vector3 PassengerPoseFileOffset { get; set; }
     public string HardpointPrefix { get; set; }
     public uint MaxPassengers { get; set; }
     public float EjectionForce { get; set; }

--- a/UdpHosts/GameServer/StaticDB/Records/vcs/TurretComponentDef.cs
+++ b/UdpHosts/GameServer/StaticDB/Records/vcs/TurretComponentDef.cs
@@ -1,7 +1,10 @@
+using FauFau.Util.CommmonDataTypes;
+
 namespace GameServer.Data.SDB.Records.vcs;
+
 public record class TurretComponentDef
 {
-    // public Vec3 GunnerPoseFileOffset { get; set; }
+    public Vector3 GunnerPoseFileOffset { get; set; }
     public uint VisualrecId { get; set; }
     public uint AnimnetId { get; set; }
     public uint GunnerPoseFile { get; set; }

--- a/UdpHosts/GameServer/StaticDB/SDBInterface.cs
+++ b/UdpHosts/GameServer/StaticDB/SDBInterface.cs
@@ -8,6 +8,7 @@ using Records.aptfs;
 using Records.dbcharacter;
 using Records.dbencounterdata;
 using Records.dbitems;
+using Records.dbphysicsmaterials;
 using Records.dbvisualrecords;
 using Records.dbzonemetadata;
 using Records.vcs;
@@ -21,15 +22,27 @@ public class SDBInterface
     private static Dictionary<uint, DeployableFunction> DeployableFunction;
     private static Dictionary<uint, DeployableCategory> DeployableCategory;
     private static Dictionary<uint, Faction> Faction;
+    private static List<FactionRelations> FactionRelations;
+    private static Dictionary<uint, List<FactionReputations>> FactionReputations;
     private static Dictionary<uint, Monster> Monster;
     private static Dictionary<uint, Turret> Turret;
+    private static Dictionary<uint, PoseType> PoseType;
+    private static Dictionary<uint, CharInfo> CharInfo;
+    private static Dictionary<byte, DamageType> DamageType;
+    private static Dictionary<byte, DamageResponse> DamageResponse;
+    private static Dictionary<uint, DamageResponseDamageType> DamageResponseDamageType;
+    private static Dictionary<uint, TinyObject> TinyObject;
 
     // dbencounterdata
     private static Dictionary<uint, MapMarkerInfo> MapMarkerInfo;
     private static Dictionary<uint, SinCardTemplate> SinCardTemplate;
 
+    // dbphysicsmaterials
+    private static Dictionary<uint, PhysicsMaterial> PhysicsMaterial;
+
     // dbvisualrecords
     private static Dictionary<uint, WarpaintPalette> WarpaintPalettes;
+    private static Dictionary<uint, VisualRecord> VisualRecord;
 
     // dbitems
     private static Dictionary<uint, AttributeCategory> AttributeCategory;
@@ -53,6 +66,7 @@ public class SDBInterface
     private static Dictionary<uint, FrameProgressionLevel> FrameProgressionLevel;
     private static Dictionary<uint, Blueprints> Blueprints;
     private static Dictionary<uint, List<Blueprint_Items>> BlueprintItems;
+    private static Dictionary<uint, List<BattleframeVisuals>> BattleframeVisuals;
 
     // dbzonemetadata
     private static Dictionary<uint, ZoneRecord> ZoneRecord;
@@ -254,6 +268,7 @@ public class SDBInterface
     private static Dictionary<uint, TurretComponentDef> TurretComponentDef;
     private static Dictionary<uint, DeployableComponentDef> DeployableComponentDef;
     private static Dictionary<uint, SpawnPointComponentDef> SpawnPointComponentDef;
+    private static Dictionary<uint, HullSegmentDef> HullSegmentDef;
 
     public static void Init(StaticDB instance)
     {
@@ -266,15 +281,27 @@ public class SDBInterface
         DeployableFunction = loader.LoadDeployableFunction();
         DeployableCategory = loader.LoadDeployableCategory();
         Faction = loader.LoadFaction();
+        FactionRelations = loader.LoadFactionRelations();
+        FactionReputations = loader.LoadFactionReputations();
         Monster = loader.LoadMonster();
         Turret = loader.LoadTurret();
+        PoseType = loader.LoadPoseType();
+        CharInfo = loader.LoadCharInfo();
+        DamageType = loader.LoadDamageType();
+        DamageResponse = loader.LoadDamageResponse();
+        DamageResponseDamageType = loader.LoadDamageResponseDamageType();
+        TinyObject = loader.LoadTinyObject();
 
         // dbencounterdata
         MapMarkerInfo = loader.LoadMapMarkerInfo();
         SinCardTemplate = loader.LoadSinCardTemplate();
 
+        // dbphysicsmaterials
+        PhysicsMaterial = loader.LoadPhysicsMaterial();
+
         // dbvisualrecords
         WarpaintPalettes = loader.LoadWarpaintPalettes();
+        VisualRecord = loader.LoadVisualRecord();
 
         // dbitems
         AttributeCategory = loader.LoadAttributeCategory();
@@ -298,6 +325,7 @@ public class SDBInterface
         FrameProgressionLevel = loader.LoadFrameProgressionLevel();
         Blueprints = loader.LoadBlueprints();
         BlueprintItems = loader.LoadBlueprintItems();
+        BattleframeVisuals = loader.LoadBattleframeVisuals();
 
         // dbzonemetadata
         ZoneRecord = loader.LoadZoneRecord();
@@ -499,6 +527,7 @@ public class SDBInterface
         TurretComponentDef = loader.LoadTurretComponentDef();
         DeployableComponentDef = loader.LoadDeployableComponentDef();
         SpawnPointComponentDef = loader.LoadSpawnPointComponentDef();
+        HullSegmentDef = loader.LoadHullSegmentDef();
     }
 
     // dbcharacter
@@ -538,16 +567,30 @@ public class SDBInterface
     public static Deployable GetDeployable(uint id) => Deployable.GetValueOrDefault(id);
     public static DeployableFunction GetDeployableFunction(uint id) => DeployableFunction.GetValueOrDefault(id);
     public static DeployableCategory GetDeployableCategory(uint id) => DeployableCategory.GetValueOrDefault(id);
+    public static DamageType GetDamageType(byte id) => DamageType.GetValueOrDefault(id);
+    public static DamageResponse GetDamageResponse(byte id) => DamageResponse.GetValueOrDefault(id);
+    public static DamageResponseDamageType GetDamageResponseDamageType(uint id) => DamageResponseDamageType.GetValueOrDefault(id);
+    public static TinyObject GetTinyObject(uint id) => TinyObject.GetValueOrDefault(id);
     public static Faction GetFaction(uint id) => Faction.GetValueOrDefault(id);
+    public static List<Faction> GetFactions() => Faction.Select(pair => pair.Value).ToList();
+    public static List<FactionRelations> GetFactionRelations() => FactionRelations;
+    public static List<FactionReputations> GetFactionReputations(uint id) => FactionReputations.GetValueOrDefault(id);
+
     public static Monster GetMonster(uint id) => Monster.GetValueOrDefault(id);
     public static Turret GetTurret(uint id) => Turret.GetValueOrDefault(id);
+    public static PoseType GetPoseType(uint id) => PoseType.GetValueOrDefault(id);
+    public static CharInfo GetCharInfo(uint id) => CharInfo.GetValueOrDefault(id);
 
     // dbencounterdata
     public static MapMarkerInfo GetMapMarkerInfo(uint id) => MapMarkerInfo.GetValueOrDefault(id);
     public static SinCardTemplate GetSinCardTemplate(uint id) => SinCardTemplate.GetValueOrDefault(id);
 
+    // dbphysicsMaterial
+    public static PhysicsMaterial GetPhysicsMaterial(uint id) => PhysicsMaterial.GetValueOrDefault(id);
+
     // dbvisualrecords
     public static WarpaintPalette GetWarpaintPalette(uint id) => WarpaintPalettes.GetValueOrDefault(id);
+    public static VisualRecord GetVisualRecord(uint id) => VisualRecord.GetValueOrDefault(id);
 
     // dbitems
     public static RootItem GetRootItem(uint id) => RootItem.GetValueOrDefault(id);
@@ -566,6 +609,7 @@ public class SDBInterface
     public static FrameProgressionLevel GetFrameProgressionLevel(uint level) => FrameProgressionLevel.GetValueOrDefault(level);
     public static Blueprints GetBlueprint(uint id) => Blueprints.GetValueOrDefault(id);
     public static List<Blueprint_Items> GetBlueprintItems(uint blueprintId) => BlueprintItems.GetValueOrDefault(blueprintId);
+    public static List<BattleframeVisuals> GetBattleframeVisuals(uint id) => BattleframeVisuals.GetValueOrDefault(id);
 
     // dbzonemetadata
     public static ZoneRecord GetZoneRecord(uint id) => ZoneRecord.GetValueOrDefault(id);
@@ -767,4 +811,5 @@ public class SDBInterface
     public static TurretComponentDef GetTurretComponentDef(uint id) => TurretComponentDef.GetValueOrDefault(id);
     public static DeployableComponentDef GetDeployableComponentDef(uint id) => DeployableComponentDef.GetValueOrDefault(id);
     public static SpawnPointComponentDef GetSpawnPointComponentDef(uint id) => SpawnPointComponentDef.GetValueOrDefault(id);
+    public static HullSegmentDef GetHullSegmentComponentDef(uint id) => HullSegmentDef.GetValueOrDefault(id);
 }

--- a/UdpHosts/GameServer/StaticDB/SDBInterface.cs
+++ b/UdpHosts/GameServer/StaticDB/SDBInterface.cs
@@ -6,8 +6,10 @@ using FauFau.Formats;
 using Records.apt;
 using Records.aptfs;
 using Records.dbcharacter;
+using Records.dbencounterdata;
 using Records.dbitems;
-using Records.dbviusalrecords;
+using Records.dbvisualrecords;
+using Records.dbzonemetadata;
 using Records.vcs;
 
 public class SDBInterface
@@ -16,8 +18,15 @@ public class SDBInterface
     private static Dictionary<uint, CharCreateLoadout> CharCreateLoadout;
     private static Dictionary<uint, Dictionary<byte, CharCreateLoadoutSlots>> CharCreateLoadoutSlots;
     private static Dictionary<uint, Deployable> Deployable;
+    private static Dictionary<uint, DeployableFunction> DeployableFunction;
+    private static Dictionary<uint, DeployableCategory> DeployableCategory;
+    private static Dictionary<uint, Faction> Faction;
     private static Dictionary<uint, Monster> Monster;
     private static Dictionary<uint, Turret> Turret;
+
+    // dbencounterdata
+    private static Dictionary<uint, MapMarkerInfo> MapMarkerInfo;
+    private static Dictionary<uint, SinCardTemplate> SinCardTemplate;
 
     // dbvisualrecords
     private static Dictionary<uint, WarpaintPalette> WarpaintPalettes;
@@ -38,7 +47,15 @@ public class SDBInterface
     private static Dictionary<uint, WeaponScope> WeaponScope;
     private static Dictionary<uint, WeaponUnderbarrel> WeaponUnderbarrel;
     private static Dictionary<uint, Ammo> Ammo;
+    private static Dictionary<uint, LevelBand> LevelBand;
     private static Dictionary<uint, ResourceNodeBeacon> ResourceNodeBeacon;
+    private static Dictionary<KeyValuePair<uint, uint>, LevelCategoryScalars> LevelCategoryScalars;
+    private static Dictionary<uint, FrameProgressionLevel> FrameProgressionLevel;
+    private static Dictionary<uint, Blueprints> Blueprints;
+    private static Dictionary<uint, List<Blueprint_Items>> BlueprintItems;
+
+    // dbzonemetadata
+    private static Dictionary<uint, ZoneRecord> ZoneRecord;
 
     // apt
     private static Dictionary<uint, BaseCommandDef> BaseCommandDef;
@@ -46,6 +63,7 @@ public class SDBInterface
     private static Dictionary<uint, StatusEffectData> StatusEffectData;
     private static Dictionary<uint, HashSet<uint>> StatusEffectTag;
     private static Dictionary<uint, AbilityData> AbilityData;
+    private static Dictionary<uint, ActiveInitiationCommandDef> ActiveInitiationCommandDef;
     private static Dictionary<uint, ImpactApplyEffectCommandDef> ImpactApplyEffectCommandDef;
     private static Dictionary<uint, ImpactToggleEffectCommandDef> ImpactToggleEffectCommandDef;
     private static Dictionary<uint, ConditionalBranchCommandDef> ConditionalBranchCommandDef;
@@ -245,8 +263,15 @@ public class SDBInterface
         CharCreateLoadout = loader.LoadCharCreateLoadout();
         CharCreateLoadoutSlots = loader.LoadCharCreateLoadoutSlots();
         Deployable = loader.LoadDeployable();
+        DeployableFunction = loader.LoadDeployableFunction();
+        DeployableCategory = loader.LoadDeployableCategory();
+        Faction = loader.LoadFaction();
         Monster = loader.LoadMonster();
         Turret = loader.LoadTurret();
+
+        // dbencounterdata
+        MapMarkerInfo = loader.LoadMapMarkerInfo();
+        SinCardTemplate = loader.LoadSinCardTemplate();
 
         // dbvisualrecords
         WarpaintPalettes = loader.LoadWarpaintPalettes();
@@ -267,7 +292,15 @@ public class SDBInterface
         WeaponScope = loader.LoadWeaponScope();
         WeaponUnderbarrel = loader.LoadWeaponUnderbarrel();
         Ammo = loader.LoadAmmo();
+        LevelBand = loader.LoadLevelBand();
         ResourceNodeBeacon = loader.LoadResourceNodeBeacon();
+        LevelCategoryScalars = loader.LoadLevelCategoryScalars();
+        FrameProgressionLevel = loader.LoadFrameProgressionLevel();
+        Blueprints = loader.LoadBlueprints();
+        BlueprintItems = loader.LoadBlueprintItems();
+
+        // dbzonemetadata
+        ZoneRecord = loader.LoadZoneRecord();
 
         // apt
         StatusEffectData = loader.LoadStatusEffectData();
@@ -275,6 +308,7 @@ public class SDBInterface
         BaseCommandDef = loader.LoadBaseCommandDef();
         CommandType = loader.LoadCommandType();
         AbilityData = loader.LoadAbilityData();
+        ActiveInitiationCommandDef = loader.LoadActiveInitiationCommandDef();
         ImpactApplyEffectCommandDef = loader.LoadImpactApplyEffectCommandDef();
         ImpactToggleEffectCommandDef = loader.LoadImpactToggleEffectCommandDef();
         WhileLoopCommandDef = loader.LoadWhileLoopCommandDef();
@@ -502,10 +536,17 @@ public class SDBInterface
 
     public static Dictionary<byte, CharCreateLoadoutSlots> GetCharCreateLoadoutSlots(uint id) => CharCreateLoadoutSlots.GetValueOrDefault(id);
     public static Deployable GetDeployable(uint id) => Deployable.GetValueOrDefault(id);
+    public static DeployableFunction GetDeployableFunction(uint id) => DeployableFunction.GetValueOrDefault(id);
+    public static DeployableCategory GetDeployableCategory(uint id) => DeployableCategory.GetValueOrDefault(id);
+    public static Faction GetFaction(uint id) => Faction.GetValueOrDefault(id);
     public static Monster GetMonster(uint id) => Monster.GetValueOrDefault(id);
     public static Turret GetTurret(uint id) => Turret.GetValueOrDefault(id);
 
-    // dbvisaulrecords
+    // dbencounterdata
+    public static MapMarkerInfo GetMapMarkerInfo(uint id) => MapMarkerInfo.GetValueOrDefault(id);
+    public static SinCardTemplate GetSinCardTemplate(uint id) => SinCardTemplate.GetValueOrDefault(id);
+
+    // dbvisualrecords
     public static WarpaintPalette GetWarpaintPalette(uint id) => WarpaintPalettes.GetValueOrDefault(id);
 
     // dbitems
@@ -519,12 +560,21 @@ public class SDBInterface
     public static WeaponScope GetWeaponScope(uint id) => WeaponScope.GetValueOrDefault(id);
     public static WeaponUnderbarrel GetWeaponUnderbarrel(uint id) => WeaponUnderbarrel.GetValueOrDefault(id);
     public static Ammo GetAmmo(uint id) => Ammo.GetValueOrDefault(id);
+    public static LevelBand GetLevelBand(uint id) => LevelBand.GetValueOrDefault(id);
     public static ResourceNodeBeacon GetResourceNodeBeacon(uint id) => ResourceNodeBeacon.GetValueOrDefault(id);
+    public static LevelCategoryScalars GetLevelCategoryScalar(uint attributeCategory, uint level) => LevelCategoryScalars.GetValueOrDefault(new KeyValuePair<uint, uint>(attributeCategory, level));
+    public static FrameProgressionLevel GetFrameProgressionLevel(uint level) => FrameProgressionLevel.GetValueOrDefault(level);
+    public static Blueprints GetBlueprint(uint id) => Blueprints.GetValueOrDefault(id);
+    public static List<Blueprint_Items> GetBlueprintItems(uint blueprintId) => BlueprintItems.GetValueOrDefault(blueprintId);
+
+    // dbzonemetadata
+    public static ZoneRecord GetZoneRecord(uint id) => ZoneRecord.GetValueOrDefault(id);
 
     // apt
     public static BaseCommandDef GetBaseCommandDef(uint id) => BaseCommandDef.GetValueOrDefault(id);
     public static CommandType GetCommandType(uint id) => CommandType.GetValueOrDefault(id);
     public static AbilityData GetAbilityData(uint id) => AbilityData.GetValueOrDefault(id);
+    public static ActiveInitiationCommandDef GetActiveInitiationCommandDef(uint id) => ActiveInitiationCommandDef.GetValueOrDefault(id);
     public static StatusEffectData GetStatusEffectData(uint id) => StatusEffectData.GetValueOrDefault(id);
     public static HashSet<uint> GetStatusEffectTag(uint id) => StatusEffectTag.GetValueOrDefault(id);
     public static ImpactApplyEffectCommandDef GetImpactApplyEffectCommandDef(uint id) => ImpactApplyEffectCommandDef.GetValueOrDefault(id);

--- a/UdpHosts/GameServer/StaticDB/SDBUtils.cs
+++ b/UdpHosts/GameServer/StaticDB/SDBUtils.cs
@@ -3,6 +3,7 @@ namespace GameServer.Data.SDB;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Numerics;
 using AeroMessages.GSS.V66.Character;
 using Records.dbcharacter;
 using Records.dbitems;
@@ -12,6 +13,11 @@ using Serilog;
 public class SDBUtils
 {
     private static readonly ILogger _logger = Log.ForContext<SDBInterface>();
+
+    public static Vector3 Vector3FromFauFau(FauFau.Util.CommmonDataTypes.Vector3 input)
+    {
+        return new Vector3(input.x, input.y, input.z);
+    }
 
     public static Dictionary<byte, CharCreateLoadoutSlots> GetDefaultLoadoutSlots(uint loadoutId)
     {
@@ -223,6 +229,11 @@ public class SDBUtils
             StatusFxId = 0,
             Turrets = new List<TurretComponentDef>(),
             Deployables = new List<DeployableComponentDef>(),
+            HullSegment = null,
+            DriverPoseFile = 0,
+            PasengerPoseFile = 0,
+            PassengerPoseOffset = Vector3.Zero,
+            DriverPoseOffset = Vector3.Zero,
         };
 
         foreach (var baseComponent in baseComponents.Values)
@@ -244,6 +255,8 @@ public class SDBUtils
                     var driverComponent = SDBInterface.GetDriverComponentDef(componentId);
                     result.HasDriverSeat = true;
                     result.DriverPosture = driverComponent.Posture;
+                    result.DriverPoseFile = driverComponent.DriverPoseFile;
+                    result.DriverPoseOffset = Vector3FromFauFau(driverComponent.DriverPoseFileOffset);
                     break;
 
                 case ComponentType.Passenger:
@@ -252,6 +265,8 @@ public class SDBUtils
                     result.PassengerPosture = passengerComponent.Posture;
                     result.HasActivePassenger = passengerComponent.ActivePassenger == 1;
                     result.SkipOnePassenger = passengerComponent.LeadingZero == 1;
+                    result.PasengerPoseFile = passengerComponent.PassengerPoseFile;
+                    result.PassengerPoseOffset = Vector3FromFauFau(passengerComponent.PassengerPoseFileOffset);
                     break;
 
                 case ComponentType.Ability:
@@ -284,6 +299,10 @@ public class SDBUtils
                 case ComponentType.SpawnPoint:
                     // TODO: Probably for allowing spawning into the vehicle
                     // var spawnPointComponent = SDBInterface.GetSpawnPointComponentDef(componentId);
+                    break;
+
+                case ComponentType.HullSegment:
+                    result.HullSegment = SDBInterface.GetHullSegmentComponentDef(componentId);
                     break;
 
                 default:
@@ -617,6 +636,11 @@ public class VehicleInfoResult
     public uint StatusFxId;
     public List<TurretComponentDef> Turrets;
     public List<DeployableComponentDef> Deployables;
+    public HullSegmentDef HullSegment;
+    public uint DriverPoseFile;
+    public uint PasengerPoseFile;
+    public Vector3 PassengerPoseOffset;
+    public Vector3 DriverPoseOffset;
 }
 
 public class ChassisWarpaintResult


### PR DESCRIPTION
Fixes some incorrect names and spacing on a few records.
When reading the StaticDB, FauFau leaves null terminators in strings as characters, which can cause unexpected issues if those strings are used in network messages. Now we will try to prune those while loading.
Adds the following tables that may be used in some future PRs.

DeployableFunction
DeployableCategory
Faction
MapMarkerInfo
SinCardTemplate
LevelBand
LevelCategoryScalars
FrameProgressionLevel
Blueprints
BlueprintItems
ZoneRecord
ActiveInitiationCommandDef
FactionRelations
FactionReputations
PoseType
CharInfo
DamageType
DamageResponse
DamageResponseDamageType
TinyObject
PhysicsMaterial
VisualRecord
BattleframeVisuals
HullSegmentDef