### PR TITLE
Fix KeyNotFoundException by adding TryGetValue checks in EntityManager

### DIFF
--- a/UdpHosts/GameServer/Systems/EntityManager/EntityManager.cs
+++ b/UdpHosts/GameServer/Systems/EntityManager/EntityManager.cs
@@ -393,7 +393,12 @@ public class EntityManager
             foreach (var entity in entities)
             {
                 float distanceThreshold = entity.GetScopeRange();
-                var currentlyScoped = ScopedPlayersByEntity[entity.EntityId];
+                if (!ScopedPlayersByEntity.TryGetValue(entity.EntityId, out var currentlyScoped))
+                {
+                    // Entity has no scoped players, skip
+                    continue;
+                }
+
                 var entityPosition = entity.Position;
                 foreach (var player in players)
                 {
@@ -1640,30 +1645,41 @@ public class EntityManager
         if (shouldFlush)
         {
             view.SerializeChangesToMemory(out var update);
-            foreach (var client in ScopedPlayersByEntity[entityId])
+
+            if (ScopedPlayersByEntity.TryGetValue(entityId, out var scopedPlayers))
             {
-                bool shouldSend = client.Status.Equals(IPlayer.PlayerStatus.Playing) || client.Status.Equals(IPlayer.PlayerStatus.Loading);
-                if (shouldSend)
+                foreach (var client in ScopedPlayersByEntity[entityId])
                 {
-                    client.NetChannels[ChannelType.UnreliableGss].SendChanges(view, entityId, update);
+                    bool shouldSend = client.Status.Equals(IPlayer.PlayerStatus.Playing) || client.Status.Equals(IPlayer.PlayerStatus.Loading);
+                    if (shouldSend && client?.NetChannels != null)
+                    {
+                        client.NetChannels[ChannelType.UnreliableGss].SendChanges(view, entityId, update);
+                    }
                 }
             }
         }
     }
 
     public void SendToScoped<TNormal>(IEntity entity, TNormal message)
-    where TNormal : class, IAero
+        where TNormal : class, IAero
     {
         var entityId = entity.EntityId;
-        foreach (var client in ScopedPlayersByEntity[entityId])
+        if (!ScopedPlayersByEntity.TryGetValue(entityId, out var scopedPlayers))
         {
-            if (client.CanReceiveGSS)
+            // No players are scoped to this entity - nothing to send to
+            return;
+        }
+
+        foreach (var client in scopedPlayers)
+        {
+            if (client?.CanReceiveGSS == true &&
+                client.NetChannels?.TryGetValue(ChannelType.UnreliableGss, out var channel) == true)
             {
-                client.NetChannels[ChannelType.UnreliableGss].SendMessage(message, entityId);
+                channel.SendMessage(message, entityId);
             }
         }
     }
- 
+
     private void OnAddedEntity(IEntity entity)
     {
         // TEMP: Hack to introduce new entities to connected players. This should be replaced with tick logic that sends down entities based on scope and distance.
@@ -1679,9 +1695,15 @@ public class EntityManager
 
     private void OnRemovedEntity(IEntity entity)
     {
-        foreach (var client in ScopedPlayersByEntity[entity.EntityId])
+        if (ScopedPlayersByEntity.TryGetValue(entity.EntityId, out var scopedPlayers))
         {
-            ScopeOut(client, entity);
+            foreach (var client in scopedPlayers.ToList()) // ToList() to avoid modification during iteration
+            {
+                if (client != null)
+                {
+                    ScopeOut(client, entity);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
Fix for the KeyNotFoundException in EntityManager that was happening after around a minute of running the GameServer, but not entering the game. This error was due to using direct indexing in a few problematic areas.

## List of changes:
- Replace direct indexing with TryGetValue in OnRemovedEntity
- Add TryGetValue guard to FlushViewChangesToScoped
- Replace direct indexing with TryGetValue in Tick.
- Added TryGetValue guard to ScopedPlayersByEntity

## Error Details:
System.Collections.Generic.KeyNotFoundException
  HResult=0x80131577
  Message=The given key '2302054457216711424' was not present in the dictionary.
  Source=System.Collections.Concurrent
  StackTrace:
   at System.Collections.Concurrent.ConcurrentDictionary`2.ThrowKeyNotFoundException(TKey key) in System.Collections.Concurrent\ConcurrentDictionary.cs:line 1124
   at GameServer.Systems.EntityManager.EntityManager.FlushChanges(IEntity entity)
   at GameServer.Entities.BaseAptitudeEntity.ClearEffect(EffectState state)
   at GameServer.Aptitude.AbilitySystem.DoRemoveEffect(EffectState activeEffect)
   at GameServer.Aptitude.AbilitySystem.ProcessTarget(IAptitudeTarget entity, UInt64 currentTime)
   at GameServer.Aptitude.AbilitySystem.Tick(Double deltaTime, UInt64 currentTime, CancellationToken ct)
   at GameServer.Shard.Tick(Double deltaTime, UInt64 currentTime, CancellationToken ct)
   at GameServer.Shard.RunThread(CancellationToken ct)
   at Shared.Udp.Utils.<>c__DisplayClass1_0.<RunThread>b__0(Object o)
   at System.Threading.Thread.StartCallback()
