### PR TITLE
Update target stack handling

### DIFF
--- a/UdpHosts/GameServer/Systems/Aptitude/Commands/Target/PeekTargetsCommand.cs
+++ b/UdpHosts/GameServer/Systems/Aptitude/Commands/Target/PeekTargetsCommand.cs
@@ -18,14 +18,22 @@ public class PeekTargetsCommand : Command, ICommand
 
         if (Params.Former == 1)
         {
-            var ok = context.FormerTargets.TryPeek(out _);
+            var ok = context.TargetStack.TryPeek(out var result);
+            if (ok)
+            {
+                context.FormerTargets = result;
+            }
 
             return ok;
         }
 
         if (Params.Current == 1)
         {
-            var ok = context.Targets.TryPeek(out _);
+            var ok = context.TargetStack.TryPeek(out var result);
+            if (ok)
+            {
+                context.Targets = result;
+            }
 
             return ok;
         }

--- a/UdpHosts/GameServer/Systems/Aptitude/Commands/Target/PopTargetsCommand.cs
+++ b/UdpHosts/GameServer/Systems/Aptitude/Commands/Target/PopTargetsCommand.cs
@@ -16,15 +16,24 @@ public class PopTargetsCommand : Command, ICommand
     {
         if (Params.Former == 1)
         {
-            var ok = context.FormerTargets.TryPop(out _);
+            var ok = context.TargetStack.TryPop(out var result);
+            if (ok)
+            {
+                context.FormerTargets = result;
+            }
 
             return ok;
         }
 
         if (Params.Current == 1)
         {
-            context.Targets = new AptitudeTargets(context.FormerTargets);
-            context.FormerTargets = new AptitudeTargets();
+            var ok = context.TargetStack.TryPop(out var result);
+            if (ok)
+            {
+                context.Targets = result;
+            }
+
+            return ok;
         }
 
         return true;

--- a/UdpHosts/GameServer/Systems/Aptitude/Commands/Target/PushTargetsCommand.cs
+++ b/UdpHosts/GameServer/Systems/Aptitude/Commands/Target/PushTargetsCommand.cs
@@ -14,17 +14,14 @@ public class PushTargetsCommand : Command, ICommand
 
     public bool Execute(Context context)
     {
-        // todo aptitude: verify what to push
-        if (Params.Former == 1 && context.FormerTargets.Count > 0)
+        if (Params.Former == 1)
         {
-            // assuming push == saving for later, this shouldnt occur and it doesnt in 1962
-            Logger.Debug("[PushTargets] Former = 1, FormerTargets count {count}", context.FormerTargets.Count);
+            context.TargetStack.Push(context.FormerTargets);
         }
 
         if (Params.Current == 1)
         {
-            context.FormerTargets = new AptitudeTargets(context.Targets);
-            context.Targets = new AptitudeTargets();
+            context.TargetStack.Push(context.Targets);
         }
 
         return true;

--- a/UdpHosts/GameServer/Systems/Aptitude/Commands/Target/TargetStackEmptyCommand.cs
+++ b/UdpHosts/GameServer/Systems/Aptitude/Commands/Target/TargetStackEmptyCommand.cs
@@ -16,9 +16,9 @@ public class TargetStackEmptyCommand : Command, ICommand
     {
         if (Params.NotEmpty == 1)
         {
-            return context.Targets.Count != 0;
+            return context.TargetStack.Count != 0;
         }
 
-        return context.Targets.Count == 0;
+        return context.TargetStack.Count == 0;
     }
 }

--- a/UdpHosts/GameServer/Systems/Aptitude/Context.cs
+++ b/UdpHosts/GameServer/Systems/Aptitude/Context.cs
@@ -27,6 +27,7 @@ public class Context
     public IAptitudeTarget Initiator { get; set; }
     public AptitudeTargets Targets { get; set; }
     public AptitudeTargets FormerTargets { get; set; }
+    public Stack<AptitudeTargets> TargetStack { get; set; } = new();
     public float Register { get; set; }
     public float FormerRegister { get; set; }
     public int Bonus { get; set; }


### PR DESCRIPTION
Added `TargetStack` to `Context` based on comparing various ability chains and command descriptions from older game versions seen in `CommandType`, that mention Target Stack specifically; updated push/pop/peek/stackEmpty commands.