### PR TITLE
Add a working NPC AI engine (brains, orders, combat styles, aranha species)

### DIFF
--- a/UdpHosts/GameServer/AIEngine.Aranha.cs
+++ b/UdpHosts/GameServer/AIEngine.Aranha.cs
@@ -1,0 +1,262 @@
+using System;
+using System.Numerics;
+using GameServer.Entities.Character;
+using GameServer.Entities.Thumper;
+
+namespace GameServer;
+
+/// <summary>
+///     The aranha species behavior. Refer to codex/ai-design.md section 4b.
+///     Contents: hull climbing, perch selection, pounce leaps at players,
+///     random leaps onto thumper hulls, and pack-hunting roles. Each NPC
+///     gets its own role and its own speed factor.
+///
+///     A species file is a partial class of AIEngine. It uses the shared
+///     brains, profiles, and movement methods. Engage() stays generic and
+///     calls the species hooks by name. Each new species gets its own
+///     AIEngine.&lt;Species&gt;.cs file with the same pattern.
+/// </summary>
+public partial class AIEngine
+{
+    // The pounce is the aranha leap attack from mid range. The original
+    // game had this behavior.
+    private const ulong PounceDurationMs = 700;
+    private const ulong PounceCooldownMs = 6000;
+    private const float PounceMinRange = 5f;
+    private const float PounceMaxRange = 11f;
+    private const float PounceArcHeight = 2.5f;
+
+    /// <summary>Returns true for a melee type that can climb. Examples: aranha workers and soldiers.</summary>
+    private static bool IsAranhaLike(AiProfile profile)
+    {
+        return profile.CanClimb && profile.PreferredRange <= 4f;
+    }
+
+    /// <summary>
+    ///     Returns the approach range of one NPC against a thumper hull.
+    ///     There are eight range steps. The entity id selects the step.
+    ///     Without the steps, all walkers stop on the same circle.
+    /// </summary>
+    private static float AranhaHullApproachRange(CharacterEntity npc)
+    {
+        return 0.4f + (((npc.EntityId >> 8) % 8) * 0.15f);
+    }
+
+    /// <summary>
+    ///     Pack hunting. Each melee NPC gets a role from its entity id.
+    ///     About 35 percent attack the target directly. The others move to
+    ///     a point on a circle around the target. The point turns slowly
+    ///     around the target. Half turn left, and half turn right. Each NPC
+    ///     has its own turn speed. The pack then surrounds the target.
+    ///     Without the roles, all NPCs follow the target in a narrow group.
+    ///     The pounce code adds the leap attacks. The gait output is a
+    ///     speed factor for this NPC. Different speeds prevent identical
+    ///     movement.
+    /// </summary>
+    private static Vector3 ComputeMeleePackGoal(CharacterEntity npc, Vector3 targetPosition, float contactRange, float horizontalDistance, ulong currentTime, out float gait)
+    {
+        gait = 0.8f + (Hash01(npc.EntityId, 0x6A17) * 0.45f);
+        var role = Hash01(npc.EntityId, 0xB07E);
+        if (role < 0.35f || horizontalDistance >= 20f)
+        {
+            return targetPosition;
+        }
+
+        var spin = role >= 0.675f ? 1f : -1f;
+        var wheelSpeed = 0.2f + (Hash01(npc.EntityId, 0x5F1A) * 0.4f);
+        var wheelTime = (float)((currentTime % 3600000UL) / 1000.0);
+        var slotAngle = (Hash01(npc.EntityId, 0xC12C7E) * 2f * MathF.PI) + (spin * wheelSpeed * wheelTime);
+        return targetPosition + new Vector3(
+            MathF.Cos(slotAngle) * (contactRange + 0.4f),
+            MathF.Sin(slotAngle) * (contactRange + 0.4f),
+            0f);
+    }
+
+    /// <summary>
+    ///     Selects the perch point of one NPC on a hull. The direction
+    ///     comes from the approach direction of the NPC, plus a small
+    ///     random angle. The height is a random value over the full hull
+    ///     height. The swarm then covers the hull from the base to the top.
+    /// </summary>
+    private static Vector3 ComputePerchOffset(CharacterEntity npc, ThumperEntity thumper, Vector3 toTarget)
+    {
+        var scale = Math.Max(thumper.Scale, 0.1f);
+        var hullHeight = 5f * scale;   // equal to the kinematic capsule height
+        var bearing = new Vector3(-toTarget.X, -toTarget.Y, 0f);
+        var length = MathF.Sqrt((bearing.X * bearing.X) + (bearing.Y * bearing.Y));
+        if (length < 0.01f)
+        {
+            bearing = new Vector3(1f, 0f, 0f);
+            length = 1f;
+        }
+
+        bearing /= length;
+
+        // Add a small random angle. NPCs that come from the same direction
+        // then get different perch points.
+        var jitter = (Hash01(npc.EntityId, 0x51EDA) - 0.5f) * 0.9f;
+        var cos = MathF.Cos(jitter);
+        var sin = MathF.Sin(jitter);
+        bearing = new Vector3((bearing.X * cos) - (bearing.Y * sin), (bearing.X * sin) + (bearing.Y * cos), 0f);
+
+        // A random height over the full climbable hull
+        var height = 0.5f + (Hash01(npc.EntityId, 0xA127) * (hullHeight - 1.2f));
+        return (bearing * 1.35f * scale) + new Vector3(0f, 0f, height);
+    }
+
+    /// <summary>
+    ///     Attaches a climber to the thumper hull. Each NPC gets its own
+    ///     perch point on the hull. The perch points cover the full hull.
+    ///     Without them, all NPCs collect on one narrow band.
+    ///     Returns true when the NPC is attached. The movement for this
+    ///     think is then complete.
+    /// </summary>
+    private bool TryAranhaLatch(CharacterEntity npc, BrainState brain, ThumperEntity thumper, Vector3 toTarget, float horizontalDistance, float deltaSeconds, ulong currentTime)
+    {
+        // Start the attach procedure outside the crowd. The radius is the
+        // hull surface radius, scaled to the thumper size, plus the width
+        // of approximately two rows of aranha bodies. With a smaller
+        // radius, the creature separation blocks the walkers. The walkers
+        // then stay outside while the leapers jump over them.
+        var latchRadius = (1.35f * Math.Max(thumper.Scale, 0.1f)) + 2.6f;
+        if (horizontalDistance >= latchRadius)
+        {
+            return false;
+        }
+
+        LatchOnThumper(npc, brain, thumper, toTarget, deltaSeconds, currentTime);
+        TryHitThumper(npc, brain, thumper, horizontalDistance, 2.5f, currentTime);
+        BroadcastPoseIfDue(npc, brain, currentTime);
+        return true;
+    }
+
+    /// <summary>Starts a pounce leap at a player target from mid range. Returns true when the leap starts.</summary>
+    private bool TryAranhaPounce(CharacterEntity npc, BrainState brain, CharacterEntity playerTarget, Vector3 toTarget, float horizontalDistance, ulong currentTime)
+    {
+        if (currentTime < brain.NextPounceAt
+            || horizontalDistance < PounceMinRange || horizontalDistance > PounceMaxRange
+            || MathF.Abs(toTarget.Z) >= 4f)
+        {
+            return false;
+        }
+
+        StartLeap(npc, brain, playerTarget.Position, 0, currentTime);
+        return true;
+    }
+
+    /// <summary>
+    ///     A climber that comes near a thumper can leap onto the hull. The
+    ///     result of a random test selects the leap for half of the NPCs.
+    ///     The other half walks. The landing point has a random height on
+    ///     the near side of the hull. Returns true when the leap starts.
+    /// </summary>
+    private bool TryAranhaHullLeap(CharacterEntity npc, BrainState brain, ThumperEntity thumper, Vector3 toTarget, float horizontalDistance, ulong currentTime)
+    {
+        if (currentTime < brain.NextPounceAt
+            || horizontalDistance < 4f || horizontalDistance > PounceMaxRange)
+        {
+            return false;
+        }
+
+        // Each NPC gets its own random result from Hash01. Entity ids
+        // increase in steps of 256. A simple parity test gives the same
+        // result to a full wave. All NPCs then leap at the same time.
+        if (Hash01(npc.EntityId, (uint)(currentTime >> 11)) < 0.5f)
+        {
+            StartLeap(npc, brain, thumper.Position + ComputePerchOffset(npc, thumper, toTarget), thumper.EntityId, currentTime);
+            return true;
+        }
+
+        // The NPC walks in this cycle. Do not repeat the random test on
+        // each think.
+        brain.NextPounceAt = currentTime + PounceCooldownMs;
+        return false;
+    }
+
+    /// <summary>
+    ///     Starts a leap. While the leap is active, only TickLeap controls
+    ///     the NPC. The walkableId parameter names the hull for the
+    ///     landing. Zero means a landing on the ground.
+    /// </summary>
+    private void StartLeap(CharacterEntity npc, BrainState brain, Vector3 target, ulong walkableId, ulong currentTime)
+    {
+        brain.LeapStart = npc.Position;
+        brain.LeapTarget = target;
+        brain.LeapWalkableId = walkableId;
+        brain.LeapStartedAt = currentTime;
+        brain.LeapEndsAt = currentTime + PounceDurationMs;
+        brain.NextPounceAt = currentTime + PounceCooldownMs + (npc.EntityId % 3000);
+        TickLeap(npc, brain, currentTime);
+    }
+
+    /// <summary>
+    ///     Sets the perch point one time. Then moves the NPC in 3D steps to
+    ///     the perch point. At the perch point, the NPC stands and points
+    ///     to the hull center.
+    /// </summary>
+    private void LatchOnThumper(CharacterEntity npc, BrainState brain, ThumperEntity thumper, Vector3 toTarget, float deltaSeconds, ulong currentTime)
+    {
+        if (!brain.HasPerch)
+        {
+            brain.PerchOffset = ComputePerchOffset(npc, thumper, toTarget);
+            brain.HasPerch = true;
+        }
+
+        var perch = thumper.Position + brain.PerchOffset;
+        var toPerch = perch - npc.Position;
+        var distance = toPerch.Length();
+        var inward = SafeNormalize(new Vector3(-brain.PerchOffset.X, -brain.PerchOffset.Y, 0f));
+
+        if (distance < 0.25f)
+        {
+            SetMovement(npc, inward, StandingMovementState, perch);
+        }
+        else
+        {
+            var step = MathF.Min(brain.Profile.FastSpeed * deltaSeconds, distance);
+            SetMovement(npc, SafeNormalize(toPerch), RunningMovementState, npc.Position + (SafeNormalize(toPerch) * step));
+        }
+    }
+
+    /// <summary>
+    ///     Moves an active leap forward. The path is a parabolic arc from
+    ///     the start point to the target point. The NPC shows the fall
+    ///     animation. At the landing: when the target is a hull, the NPC
+    ///     attaches at the landing point. If not, the NPC lands on the
+    ///     ground. The NPC can attack immediately after the landing.
+    /// </summary>
+    private void TickLeap(CharacterEntity npc, BrainState brain, ulong currentTime)
+    {
+        var t = Math.Clamp((currentTime - brain.LeapStartedAt) / (float)PounceDurationMs, 0f, 1f);
+        var position = Vector3.Lerp(brain.LeapStart, brain.LeapTarget, t);
+        position.Z += PounceArcHeight * 4f * t * (1f - t);
+
+        var aim = SafeNormalize(brain.LeapTarget - npc.Position);
+        SetMovement(npc, aim == Vector3.Zero ? npc.AimDirection : aim, FallingMovementState, position);
+
+        if (t >= 1f)
+        {
+            brain.LeapEndsAt = 0;
+            if (brain.LeapWalkableId != 0
+                && _shard.Entities.TryGetValue(brain.LeapWalkableId, out var leapTarget)
+                && leapTarget is ThumperEntity perchThumper)
+            {
+                // The NPC lands on the hull. The landing point becomes the perch point.
+                brain.PerchOffset = brain.LeapTarget - perchThumper.Position;
+                brain.HasPerch = true;
+                npc.SetPosition(brain.LeapTarget);
+            }
+            else
+            {
+                var landing = brain.LeapTarget;
+                landing.Z = _shard.Physics.GetGroundHeight(landing) ?? landing.Z;
+                npc.SetPosition(landing);
+            }
+
+            brain.LeapWalkableId = 0;
+            brain.NextFireAt = currentTime; // The NPC can bite immediately after the landing.
+        }
+
+        _shard.Movement.BroadcastCharacterPose(npc);
+    }
+}

--- a/UdpHosts/GameServer/AIEngine.cs
+++ b/UdpHosts/GameServer/AIEngine.cs
@@ -1,10 +1,1497 @@
-﻿using System.Threading;
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Text.RegularExpressions;
+using System.Threading;
+using AeroMessages.GSS.Character;
+using AeroMessages.GSS.Character.Event;
+using GameServer.Entities;
+using GameServer.Entities.Character;
+using GameServer.Entities.Thumper;
+using GameServer.StaticDB;
+using GameServer.StaticDB.Records.dbcharacter;
+using Serilog;
 
 namespace GameServer;
 
-public class AIEngine
+public readonly record struct AiBrainDiagnostic(
+    ulong EntityId,
+    ulong TargetEntityId,
+    string Mode,
+    Vector3 Home,
+    bool Aggressive,
+    bool HasWeapon,
+    ulong NextFireAt,
+    string Order);
+
+// Orders are the interface between content systems (encounters, missions)
+// and NPC brains. A brain that has no order uses its default behavior.
+// A brain that has an order obeys the order. An order overrides the leash.
+// Refer to codex/ai-design.md section 4.
+public abstract record AiOrder;
+public sealed record AttackEntityOrder(ulong TargetEntityId) : AiOrder;
+public sealed record DefendPointOrder(Vector3 Position, float Radius) : AiOrder;
+public sealed record MoveToOrder(Vector3 Position) : AiOrder;
+public sealed record FollowEntityOrder(ulong TargetEntityId, float Distance) : AiOrder;
+
+/// <summary>
+///     The server-side NPC brain system. It controls targets, orders,
+///     movement classes, combat styles, and weapon fire. Species behavior
+///     is in partial class files (example: AIEngine.Aranha.cs). The
+///     Engage() method calls the species hooks by name.
+/// </summary>
+public partial class AIEngine
 {
+    /// <summary>
+    ///     The position of the NPC muzzle on the rig capsule, as a fraction
+    ///     of the capsule height. The "npcfx" admin command can change this
+    ///     value at run time. The default values in this group come from
+    ///     live tests with aranhas.
+    /// </summary>
+    public static float NpcMuzzleFraction = 0.9f;
+
+    /// <summary>
+    ///     The hardpoint id sent in AbilityProjectileFired. The client uses
+    ///     it to attach the visible projectile. Hardpoint 2 is the aranha
+    ///     spit muzzle. The ability chain of the Aranha Queen names it.
+    /// </summary>
+    public static uint NpcFxHardpoint = 2;
+
+    /// <summary>
+    ///     The visual projectile start offset, in local meters
+    ///     (right, forward, up). Sent in AbilityProjectileFired.
+    /// </summary>
+    public static Vector3 NpcFxOffset = new(0f, 0.2f, 0.9f);
+
+    /// <summary>
+    ///     A debug aid ("npcfx aimpoint" admin command). When this value is
+    ///     set, each armed hostile NPC stops and fires at this point. The
+    ///     NPC does not attack players in this mode.
+    /// </summary>
+    public static Vector3? NpcAimPointOverride = null;
+
+    // ---- Think interval ----------------------------------------------------
+    // Brains think 4 times each second. Each think writes movement data.
+    // The client interpolates between the writes. All times in this class
+    // are shard milliseconds.
+    private const ulong ThinkIntervalMs = 250;
+
+    // ---- Target selection and leash (values in meters) ---------------------
+    private const float DefaultAggroRange = 45f;      // player detection radius, used when the monster row has no value
+    private const ulong TargetMemoryMs = 5000;        // an NPC follows a target it cannot see for this many milliseconds
+    private const float LeashRange = 80f;             // an NPC farther than this from home stops its attack and returns
+    private const float HomeArriveRange = 3f;         // an NPC nearer to home than this has arrived
+    private const float OrderArriveRange = 2.5f;      // a MoveToOrder nearer to its goal than this is complete
+    private const float ThumperAggroRange = 60f;      // hostile NPCs in this radius attack an active thumper
+
+    // ---- Combat-style hold distances (values in meters) --------------------
+    // GetProfile selects a combat style for each monster type. The weapon
+    // range and the behavior tokens control the selection. These constants
+    // are the standard hold distances for each style.
+    private const float MeleeRange = 2.5f;
+    private const float RangedHoldRange = 18f;
+    private const float SniperHoldRange = 38f;
+
+    // ---- Movement ----------------------------------------------------------
+    private const float DefaultNormalSpeed = 4.5f;    // walk speed in m/s, used when the monster row has no value
+    private const float DefaultFastSpeed = 7f;        // chase speed in m/s, used when the monster row has no value
+    private const float FlyerHoverHeight = 4f;        // a flyer stays this many meters above a target on the ground
+
+    // ---- Weapon fire timing (values in milliseconds) -----------------------
+    private const uint DefaultTriggerPullMs = 1500;   // burst length, used when the weapon has no value
+    private const uint DefaultFireRestMs = 500;       // pause between bursts
+
+    // ---- Thumper melee damage (PLACEHOLDER) --------------------------------
+    // Thumper integrity is a counter in the encounter code. Real weapon
+    // damage will replace this. Refer to codex/damage-design.md, phase D1.
+    private const uint ThumperDamagePerHit = 4;
+    private const ulong ThumperHitCooldownMs = 2500;
+
+    // ---- Movement-state words (replicated client animation states) ---------
+    private const short StandingMovementState = 0x1000;
+    private const short RunningMovementState = 0x2004;
+    private const short FallingMovementState = 0x3004;
+
+    // A monster behavior string can contain tunable values.
+    // Example: "GiantAranhaMiniBoss(eggSackCooldown=10000)".
+    private static readonly Regex BehaviorParamRegex = new(@"(?<key>[A-Za-z0-9_]+)\s*=\s*(?<value>-?[0-9.]+)", RegexOptions.Compiled);
+
+    private readonly IShard _shard;
+    private readonly ILogger _logger;
+
+    // Each living NPC has one BrainState, with the entity id as the key.
+    // Each character type has one AiProfile, derived from SDB data one time
+    // and then cached. Orders and passive overrides exist only for the
+    // entities that have them.
+    private readonly ConcurrentDictionary<ulong, BrainState> _brains = new();
+    private readonly ConcurrentDictionary<ulong, AiOrder> _orders = new();
+    private readonly ConcurrentDictionary<uint, AiProfile> _profiles = new();
+    private readonly ConcurrentDictionary<ulong, bool> _passiveOverrides = new();
+    private Dictionary<(uint A, uint B), sbyte> _factionStance;
+    private Dictionary<uint, sbyte> _factionDefaultStance;
+    private ulong _nextThinkAt;
+
+    public AIEngine(IShard shard)
+    {
+        _shard = shard;
+        _logger = shard.Logger.ForContext<AIEngine>();
+    }
+
+    /// <summary>Idle = ambient behavior at home; Return = walking back after a leash or lost target.</summary>
+    private enum BrainMode
+    {
+        Idle,
+        Return,
+    }
+
+    /// <summary>Returns a diagnostics record for each live brain. The /api/snapshot endpoint serves this data.</summary>
+    public AiBrainDiagnostic[] SnapshotBrains()
+    {
+        return _brains.Select(pair =>
+                                  {
+                                      var brain = pair.Value;
+                                      _orders.TryGetValue(pair.Key, out var order);
+                                      return new AiBrainDiagnostic(
+                                          pair.Key,
+                                          brain.TargetEntityId,
+                                          brain.Mode.ToString(),
+                                          brain.Home,
+                                          brain.Profile.Aggressive && !IsPassive(pair.Key),
+                                          brain.Profile.HasWeapon,
+                                          brain.NextFireAt,
+                                          order?.ToString() ?? string.Empty);
+                                  })
+                      .ToArray();
+    }
+
+    /// <summary>Gives an order to an NPC brain. The new order replaces the current order.</summary>
+    public void IssueOrder(ulong entityId, AiOrder order)
+    {
+        _orders[entityId] = order;
+    }
+
+    /// <summary>Removes the order of an NPC. The brain then uses its default behavior.</summary>
+    public void ClearOrder(ulong entityId)
+    {
+        _orders.TryRemove(entityId, out _);
+    }
+
+    /// <summary>Sets the passive override for one entity. A passive NPC does not select targets. The faction has no effect on this.</summary>
+    public void SetPassive(ulong entityId, bool passive)
+    {
+        if (passive)
+        {
+            _passiveOverrides[entityId] = true;
+        }
+        else
+        {
+            _passiveOverrides.TryRemove(entityId, out _);
+        }
+    }
+
+    /// <summary>Returns true when the entity has a passive override. Refer to <see cref="SetPassive"/>.</summary>
+    public bool IsPassive(ulong entityId)
+    {
+        return _passiveOverrides.TryGetValue(entityId, out var passive) && passive;
+    }
+
+    /// <summary>Removes all cached profiles and brains. New brains then use the current GetProfile logic.</summary>
+    public int ClearProfiles()
+    {
+        var count = _profiles.Count;
+        _profiles.Clear();
+        _brains.Clear();
+        return count;
+    }
+
+    /// <summary>Sets the passive override on each live brain. This is a debug aid.</summary>
+    public int SetAllPassive(bool passive)
+    {
+        var count = 0;
+        foreach (var entityId in _brains.Keys.ToArray())
+        {
+            SetPassive(entityId, passive);
+            count++;
+        }
+
+        return count;
+    }
+
+    /// <summary>Returns true when the faction is hostile to the player faction. Players spawn as faction 1 (Accord).</summary>
+    public bool IsHostileTowardPlayers(uint npcFactionId)
+    {
+        return IsHostileTowardFaction(npcFactionId, 1);
+    }
+
+    /// <summary>
+    ///     The shard-tick entry point. The method runs one time for each
+    ///     think interval. It ticks the brain of each living NPC. It then
+    ///     applies creature separation. It removes the state of entities
+    ///     that no longer exist.
+    /// </summary>
     public void Tick(double deltaTime, ulong currentTime, CancellationToken ct)
     {
+        if (currentTime < _nextThinkAt)
+        {
+            return;
+        }
+
+        _nextThinkAt = currentTime + ThinkIntervalMs;
+        var deltaSeconds = Math.Max((float)deltaTime / 1000f, ThinkIntervalMs / 1000f);
+
+        var seen = new HashSet<ulong>();
+        foreach (var character in _shard.Entities.Values.OfType<CharacterEntity>().ToArray())
+        {
+            if (ct.IsCancellationRequested)
+            {
+                return;
+            }
+
+            if (character.IsPlayerControlled || !IsLiving(character))
+            {
+                _brains.TryRemove(character.EntityId, out _);
+                _orders.TryRemove(character.EntityId, out _);
+                continue;
+            }
+
+            seen.Add(character.EntityId);
+            TickNpc(character, deltaSeconds, currentTime);
+            ApplySeparation(character, currentTime);
+        }
+
+        // Remove the brains and the orders of entities that no longer exist
+        foreach (var staleId in _brains.Keys.Where(id => !seen.Contains(id)).ToArray())
+        {
+            _brains.TryRemove(staleId, out _);
+            _orders.TryRemove(staleId, out _);
+            _passiveOverrides.TryRemove(staleId, out _);
+        }
+
+        foreach (var staleId in _orders.Keys.Where(id => !seen.Contains(id)).ToArray())
+        {
+            _orders.TryRemove(staleId, out _);
+        }
+    }
+
+    /// <summary>
+    ///     Returns a well-mixed hash value between 0 and 1. Entity ids
+    ///     increase in steps of 256. Because of this, simple bit selection
+    ///     gives only a small set of values. Always use this hash for
+    ///     per-entity random values.
+    /// </summary>
+    private static float Hash01(ulong id, uint salt)
+    {
+        var h = (uint)(id >> 8) ^ salt;
+        h *= 2654435761u;
+        h ^= h >> 16;
+        return (h & 0xFFFF) / 65536f;
+    }
+
+    /// <summary>Returns the body radius for creature separation. It is the pose physics radius multiplied by the visual scale. It covers the body only, not the legs.</summary>
+    private static float ComputeBodyRadius(CharacterEntity npc)
+    {
+        if (npc.Collision is CharacterCollisionComponent collision)
+        {
+            var baseRadius = collision.PoseTypeRecord?.PhysicsRadius ?? 0.5f;
+            if (baseRadius <= 0.05f)
+            {
+                baseRadius = 0.5f;
+            }
+
+            return Math.Clamp(baseRadius * Math.Max(collision.Scale, 0.1f), 0.3f, 2f);
+        }
+
+        return 0.5f;
+    }
+
+    private static bool ContainsAny(string value, params string[] tokens)
+    {
+        foreach (var token in tokens)
+        {
+            if (value.Contains(token, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    ///     One think for one brain. The priority sequence is:
+    ///     1. Continue an active leap. 2. Obey an order. 3. Return home.
+    ///     4. For hostile NPCs only: select a target and engage it.
+    /// </summary>
+    private void TickNpc(CharacterEntity npc, float deltaSeconds, ulong currentTime)
+    {
+        var brain = _brains.GetOrAdd(npc.EntityId, _ => new BrainState
+        {
+            Home = npc.Position,
+            Profile = GetProfile(npc),
+            BodyRadius = ComputeBodyRadius(npc),
+        });
+
+        if (!brain.WeaponAligned)
+        {
+            brain.WeaponAligned = true;
+            if (brain.Profile.PreferredWeaponIndex != 0 && npc.WeaponIndex.Index != brain.Profile.PreferredWeaponIndex)
+            {
+                npc.SetWeaponIndex(new WeaponIndexData
+                {
+                    Index = brain.Profile.PreferredWeaponIndex, Unk1 = 1, Unk2 = 0, Time = _shard.CurrentTime
+                });
+            }
+        }
+
+        // While a leap is active, only the leap controls the NPC
+        if (brain.LeapEndsAt > currentTime)
+        {
+            TickLeap(npc, brain, currentTime);
+            return;
+        }
+
+        // An order has priority over all other behavior, the leash included
+        if (TryExecuteOrder(npc, brain, deltaSeconds, currentTime))
+        {
+            return;
+        }
+
+        if (brain.Mode == BrainMode.Return)
+        {
+            TickReturn(npc, brain, deltaSeconds, currentTime);
+            return;
+        }
+
+        if (!brain.Profile.Aggressive || IsPassive(npc.EntityId))
+        {
+            // This NPC is not hostile, or a passive override is set.
+            // The NPC stands still. Wander behavior is a future feature.
+            return;
+        }
+
+        // Debug aim-point mode: fire at the fixed point and ignore targets
+        if (NpcAimPointOverride is Vector3 aimPoint && brain.Profile.HasWeapon)
+        {
+            var pointAim = ComputeAttackAim(npc, aimPoint);
+            if (pointAim != Vector3.Zero)
+            {
+                SetMovement(npc, pointAim, StandingMovementState);
+                if (currentTime >= brain.NextFireAt)
+                {
+                    npc.SetAimDirection(pointAim);
+                    AnnounceBurst(npc, pointAim);
+                    _shard.WeaponSim.OnFireWeaponProjectile(npc, _shard.CurrentTime, pointAim);
+                    brain.NextFireAt = currentTime + brain.Profile.FireCooldownMs;
+                }
+            }
+
+            return;
+        }
+
+        var (playerTarget, thumperTarget) = ResolveTarget(npc, brain, currentTime);
+        if (playerTarget == null && thumperTarget == null)
+        {
+            var hadTarget = brain.TargetEntityId != 0;
+            brain.TargetEntityId = 0;
+
+            if (Vector3.Distance(npc.Position, brain.Home) > HomeArriveRange * 2)
+            {
+                brain.Mode = BrainMode.Return;
+                return;
+            }
+
+            SetMovement(npc, Vector3.Zero, StandingMovementState);
+            if (hadTarget)
+            {
+                _shard.Movement.BroadcastCharacterPose(npc);
+            }
+
+            return;
+        }
+
+        // Leash: the NPC is too far from home. It stops the attack and returns.
+        if (Vector3.Distance(npc.Position, brain.Home) > LeashRange)
+        {
+            _logger.Debug("NPC {NpcId} leashing, returning home", npc.EntityId);
+            brain.TargetEntityId = 0;
+            brain.Mode = BrainMode.Return;
+            return;
+        }
+
+        Engage(npc, brain, playerTarget, thumperTarget, deltaSeconds, currentTime);
+    }
+
+    /// <summary>
+    ///     Obeys the current order of the entity, if the entity has one.
+    ///     Returns true when an order used this think. A complete order
+    ///     removes itself. Examples: the NPC arrives, or the target is dead.
+    /// </summary>
+    private bool TryExecuteOrder(CharacterEntity npc, BrainState brain, float deltaSeconds, ulong currentTime)
+    {
+        if (!_orders.TryGetValue(npc.EntityId, out var order))
+        {
+            return false;
+        }
+
+        brain.Mode = BrainMode.Idle;
+        switch (order)
+        {
+            case AttackEntityOrder attack:
+                _shard.Entities.TryGetValue(attack.TargetEntityId, out var target);
+                if (target is ThumperEntity { IsAttackable: true } thumper)
+                {
+                    brain.TargetEntityId = thumper.EntityId;
+                    Engage(npc, brain, null, thumper, deltaSeconds, currentTime);
+                    return true;
+                }
+
+                if (target is CharacterEntity character && IsLiving(character))
+                {
+                    brain.TargetEntityId = character.EntityId;
+                    brain.TargetLastSeenAt = currentTime;
+                    Engage(npc, brain, character, null, deltaSeconds, currentTime);
+                    return true;
+                }
+
+                // The target is destroyed or removed. The order is complete.
+                ClearOrder(npc.EntityId);
+                return false;
+
+            case MoveToOrder move:
+                if (MoveTowardGoal(npc, brain, move.Position, OrderArriveRange, deltaSeconds, currentTime))
+                {
+                    ClearOrder(npc.EntityId);
+                }
+
+                return true;
+
+            case DefendPointOrder defend:
+                var intruder = FindNearestPlayer(npc, defend.Radius, defend.Position);
+                if (intruder != null)
+                {
+                    brain.TargetEntityId = intruder.EntityId;
+                    brain.TargetLastSeenAt = currentTime;
+                    Engage(npc, brain, intruder, null, deltaSeconds, currentTime);
+                    return true;
+                }
+
+                brain.TargetEntityId = 0;
+                MoveTowardGoal(npc, brain, defend.Position, HomeArriveRange, deltaSeconds, currentTime);
+                return true;
+
+            case FollowEntityOrder follow:
+                _shard.Entities.TryGetValue(follow.TargetEntityId, out var leaderEntity);
+                if (leaderEntity is not CharacterEntity leader || !IsLiving(leader))
+                {
+                    ClearOrder(npc.EntityId);
+                    return false;
+                }
+
+                if (Vector3.Distance(npc.Position, leader.Position) > follow.Distance)
+                {
+                    MoveTowardGoal(npc, brain, leader.Position, follow.Distance, deltaSeconds, currentTime);
+                }
+                else
+                {
+                    SetMovement(npc, SafeNormalize(leader.Position - npc.Position), StandingMovementState);
+                    BroadcastPoseIfDue(npc, brain, currentTime);
+                }
+
+                return true;
+
+            default:
+                return false;
+        }
+    }
+
+    /// <summary>Moves the NPC toward a goal position. The movement class controls the path. Returns true when the NPC arrives.</summary>
+    private bool MoveTowardGoal(CharacterEntity npc, BrainState brain, Vector3 goal, float arriveRange, float deltaSeconds, ulong currentTime)
+    {
+        var toGoal = goal - npc.Position;
+        var distance = toGoal.Length();
+        if (distance <= arriveRange || brain.Profile.Stationary)
+        {
+            SetMovement(npc, Vector3.Zero, StandingMovementState);
+            BroadcastPoseIfDue(npc, brain, currentTime);
+            return distance <= arriveRange;
+        }
+
+        Vector3 next;
+        if (brain.Profile.Flying)
+        {
+            var step = Math.Min(brain.Profile.FastSpeed * deltaSeconds, distance);
+            next = npc.Position + (SafeNormalize(toGoal) * step);
+        }
+        else
+        {
+            var horizontal = new Vector3(toGoal.X, toGoal.Y, 0f);
+            var horizontalDistance = horizontal.Length();
+            var step = Math.Min(brain.Profile.FastSpeed * deltaSeconds, Math.Max(horizontalDistance, 0.01f));
+            next = npc.Position + (SafeNormalize(horizontal) * step);
+            var fallbackZ = npc.Position.Z + Math.Clamp(goal.Z - npc.Position.Z, -step, step);
+            next.Z = _shard.Physics.GetGroundHeight(next) ?? fallbackZ;
+        }
+
+        SetMovement(npc, SafeNormalize(toGoal), RunningMovementState, next);
+        BroadcastPoseIfDue(npc, brain, currentTime);
+        return false;
+    }
+
+    /// <summary>
+    ///     The combat core. It moves the NPC and makes attacks against the
+    ///     target. The target is a player or a thumper. When both are set,
+    ///     the thumper is the target. The method first calls the species
+    ///     hooks (refer to AIEngine.Aranha.cs). A species hook can complete
+    ///     the think and return. If no hook completes the think, movement
+    ///     runs for the movement class of the NPC. An attack attempt follows.
+    /// </summary>
+    private void Engage(CharacterEntity npc, BrainState brain, CharacterEntity playerTarget, ThumperEntity thumperTarget, float deltaSeconds, ulong currentTime)
+    {
+        var targetPosition = thumperTarget?.Position ?? playerTarget.Position;
+
+        // Against a thumper, each creature uses its own combat range.
+        // The minimum is 2.5 m, so that no creature enters the drill model.
+        // Melee types attack the hull. Ranged types fire from their hold
+        // distance. An earlier constant 8 m range kept all creatures in one
+        // wide circle, out of the reach of their attacks.
+        var contactRange = thumperTarget != null
+            ? Math.Max(2.5f, brain.Profile.PreferredRange)
+            : brain.Profile.PreferredRange;
+        if (brain.Profile.Flying)
+        {
+            // The hover point of a flyer is above the target. The contact
+            // range must not be smaller than the hover height, because the
+            // flyer can never reach such a range.
+            contactRange = Math.Max(contactRange, FlyerHoverHeight + 1f);
+        }
+
+        var toTarget = targetPosition - npc.Position;
+        var distance = toTarget.Length();
+        var aimDirection = SafeNormalize(toTarget);
+
+        // A ranged NPC always keeps its pose aimed along the ballistic
+        // firing solution, also while it moves. The client launches the
+        // visible tracer along the pose aim. An earlier version changed the
+        // aim between the flat chase direction and the pitched arc. That
+        // made the models rock, and shots fired during movement hit the
+        // ground at the feet of the NPC.
+        if (brain.Profile.HasWeapon && brain.Profile.PreferredRange > MeleeRange && playerTarget != null)
+        {
+            var attackAim = ComputeAttackAim(npc, targetPosition);
+            if (attackAim != Vector3.Zero)
+            {
+                aimDirection = attackAim;
+            }
+        }
+
+        // Ground units must not move along the full 3D direction. That
+        // walked NPCs into the air when a player used the jetpack. A ground
+        // unit follows the target in the horizontal plane only. It follows
+        // the target height at a limited slope, and only while the target
+        // is on the ground. The Z of a target on the ground is equal to the
+        // terrain height at the target position.
+        var horizontal = new Vector3(toTarget.X, toTarget.Y, 0f);
+        var horizontalDistance = horizontal.Length();
+        var moveDirection = SafeNormalize(horizontal);
+        var targetGrounded = thumperTarget != null || !playerTarget.IsAirborne;
+
+        if (thumperTarget == null && brain.HasPerch)
+        {
+            brain.HasPerch = false;
+        }
+
+        // The aranha species hooks (AIEngine.Aranha.cs): attach to a hull
+        // at a perch point, pounce on players, or leap onto a thumper hull
+        if (IsAranhaLike(brain.Profile))
+        {
+            if (thumperTarget != null)
+            {
+                contactRange = AranhaHullApproachRange(npc);
+                if (TryAranhaLatch(npc, brain, thumperTarget, toTarget, horizontalDistance, deltaSeconds, currentTime))
+                {
+                    return;
+                }
+            }
+
+            if (playerTarget != null && thumperTarget == null
+                && TryAranhaPounce(npc, brain, playerTarget, toTarget, horizontalDistance, currentTime))
+            {
+                return;
+            }
+
+            if (thumperTarget != null
+                && TryAranhaHullLeap(npc, brain, thumperTarget, toTarget, horizontalDistance, currentTime))
+            {
+                return;
+            }
+        }
+
+        if (brain.Profile.Stationary)
+        {
+            // Turrets and towers turn to the target. They do not move.
+            SetMovement(npc, aimDirection, StandingMovementState);
+        }
+        else if (brain.Profile.Flying)
+        {
+            // A flyer moves in full 3D to a hover point. The hover point is
+            // above a target on the ground. For a target in the air, the
+            // hover point is level with the target.
+            var goal = targetGrounded ? targetPosition + new Vector3(0f, 0f, FlyerHoverHeight) : targetPosition;
+            var toGoal = goal - npc.Position;
+            var goalDistance = toGoal.Length();
+            if (distance <= contactRange)
+            {
+                SetMovement(npc, aimDirection, StandingMovementState);
+            }
+            else
+            {
+                var step = Math.Min(brain.Profile.FastSpeed * deltaSeconds, Math.Max(goalDistance - contactRange, 0f));
+                SetMovement(npc, aimDirection, RunningMovementState, npc.Position + (SafeNormalize(toGoal) * step));
+            }
+        }
+        else if (playerTarget != null && brain.Profile.PreferredRange > MeleeRange
+                 && distance < brain.Profile.PreferredRange * 0.5f
+                 && moveDirection != Vector3.Zero)
+        {
+            // The target is inside the hold distance. The NPC moves back.
+            // This check uses the 3D distance. A player high on a cliff is
+            // not too near, although the horizontal distance is small. A
+            // move back would decrease the height that the weapon can reach.
+            var step = brain.Profile.NormalSpeed * deltaSeconds;
+            var next = npc.Position - (moveDirection * step);
+            next.Z = _shard.Physics.GetGroundHeight(next) ?? npc.Position.Z;
+            SetMovement(npc, aimDirection, RunningMovementState, next);
+        }
+        else if (distance <= contactRange || moveDirection == Vector3.Zero)
+        {
+            // The target is in reach, or the NPC is directly below a target
+            // in the air. The NPC stands and aims.
+            SetMovement(npc, aimDirection, StandingMovementState);
+        }
+        else
+        {
+            // Melee NPCs hunt as a pack. Some attack directly. Some move
+            // around the target. Each NPC has its own speed factor. Refer
+            // to ComputeMeleePackGoal in AIEngine.Aranha.cs.
+            var moveTo = targetPosition;
+            var gait = 1f;
+            if (playerTarget != null && brain.Profile.PreferredRange <= 4f)
+            {
+                moveTo = ComputeMeleePackGoal(npc, targetPosition, contactRange, horizontalDistance, currentTime, out gait);
+            }
+
+            var goalDelta = new Vector3(moveTo.X - npc.Position.X, moveTo.Y - npc.Position.Y, 0f);
+            var goalDistance = goalDelta.Length();
+            var goalDirection = goalDistance > 0.01f ? goalDelta / goalDistance : moveDirection;
+            var step = Math.Min(brain.Profile.FastSpeed * gait * deltaSeconds, moveTo == targetPosition ? Math.Max(horizontalDistance - contactRange, 0f) : goalDistance);
+            var next = npc.Position + (goalDirection * step);
+
+            // Use the real terrain height when zone collision data is
+            // loaded. If not, follow the height of a target on the ground
+            // at a limited slope. For a climber that attacks a thumper, the
+            // thumper hull is also a walkable surface.
+            var walkableId = (thumperTarget != null && brain.Profile.CanClimb) ? thumperTarget.EntityId : 0UL;
+            var fallbackZ = targetGrounded
+                ? npc.Position.Z + Math.Clamp(targetPosition.Z - npc.Position.Z, -step, step)
+                : npc.Position.Z;
+            next.Z = _shard.Physics.GetGroundHeight(next, walkableId) ?? fallbackZ;
+
+            SetMovement(npc, aimDirection, RunningMovementState, next);
+        }
+
+        if (thumperTarget != null)
+        {
+            // This check uses the horizontal distance, the same measure as
+            // the movement code. The movement code stops an NPC at exactly
+            // the contact range, measured horizontally. The feet of the NPC
+            // are a small distance above or below the thumper base. Because
+            // of this, a 3D distance check against the same constant always
+            // failed by a few millimeters. The NPCs then never attacked.
+            TryHitThumper(npc, brain, thumperTarget, horizontalDistance, contactRange, currentTime);
+        }
+        else
+        {
+            TryFire(npc, brain, playerTarget, distance, currentTime);
+        }
+
+        BroadcastPoseIfDue(npc, brain, currentTime);
+    }
+
+    /// <summary>
+    ///     Keeps creatures apart. Each creature has a horizontal disc with
+    ///     the width of its body (physics radius multiplied by scale). Other
+    ///     creatures must stay out of this disc. Without this rule, a pack
+    ///     moves into one point, and one burst of fire kills all of them.
+    /// </summary>
+    private void ApplySeparation(CharacterEntity npc, ulong currentTime)
+    {
+        if (!_brains.TryGetValue(npc.EntityId, out var brain)
+            || brain.Profile.Stationary
+            || brain.LeapEndsAt > currentTime
+            || brain.HasPerch)
+        {
+            return;
+        }
+
+        var myRadius = brain.BodyRadius;
+        var push = Vector3.Zero;
+        foreach (var entity in _shard.Entities.Values)
+        {
+            if (entity is not CharacterEntity other
+                || other.EntityId == npc.EntityId
+                || other.IsPlayerControlled
+                || !IsLiving(other))
+            {
+                continue;
+            }
+
+            var otherRadius = _brains.TryGetValue(other.EntityId, out var otherBrain) ? otherBrain.BodyRadius : 0.5f;
+            var minDistance = myRadius + otherRadius;
+            var dx = npc.Position.X - other.Position.X;
+            var dy = npc.Position.Y - other.Position.Y;
+            var distanceSq = (dx * dx) + (dy * dy);
+            if (distanceSq >= minDistance * minDistance || distanceSq < 0.000001f)
+            {
+                if (distanceSq < 0.000001f)
+                {
+                    // The two creatures are at the same point. Push this
+                    // creature in a direction set by its entity id.
+                    var angle = (npc.EntityId % 360) * (MathF.PI / 180f);
+                    push += new Vector3(MathF.Cos(angle), MathF.Sin(angle), 0f) * minDistance;
+                }
+
+                continue;
+            }
+
+            var distance = MathF.Sqrt(distanceSq);
+            var overlap = minDistance - distance;
+            push += new Vector3(dx / distance, dy / distance, 0f) * overlap;
+        }
+
+        if (push == Vector3.Zero)
+        {
+            return;
+        }
+
+        // Limit the push for each think. The creatures then move apart
+        // slowly, which looks natural.
+        var magnitude = push.Length();
+        if (magnitude > 1.2f)
+        {
+            push *= 1.2f / magnitude;
+        }
+
+        var corrected = npc.Position + push;
+        var walkableId = 0UL;
+        if (brain.Profile.CanClimb && brain.TargetEntityId != 0
+            && _shard.Entities.TryGetValue(brain.TargetEntityId, out var climbTarget)
+            && climbTarget is Entities.Thumper.ThumperEntity)
+        {
+            walkableId = brain.TargetEntityId;
+        }
+
+        corrected.Z = _shard.Physics.GetGroundHeight(corrected, walkableId) ?? npc.Position.Z;
+        npc.SetPosition(corrected);
+    }
+
+    /// <summary>Moves the NPC back to its home point. This runs after a leash stop or a lost target.</summary>
+    private void TickReturn(CharacterEntity npc, BrainState brain, float deltaSeconds, ulong currentTime)
+    {
+        var toHome = brain.Home - npc.Position;
+        var distance = toHome.Length();
+        if (distance <= HomeArriveRange)
+        {
+            brain.Mode = BrainMode.Idle;
+            SetMovement(npc, Vector3.Zero, StandingMovementState);
+            _shard.Movement.BroadcastCharacterPose(npc);
+            return;
+        }
+
+        var direction = SafeNormalize(toHome);
+        var step = Math.Min(brain.Profile.FastSpeed * deltaSeconds, distance);
+        SetMovement(npc, direction, RunningMovementState, npc.Position + (direction * step));
+        BroadcastPoseIfDue(npc, brain, currentTime);
+    }
+
+    /// <summary>
+    ///     Default target selection. The brain keeps its current target
+    ///     while the target is valid. A lost player target stays in memory
+    ///     for TargetMemoryMs. If there is no target, the brain selects the
+    ///     nearest player in the detection range. If there is no player,
+    ///     the brain selects an attackable thumper in ThumperAggroRange.
+    /// </summary>
+    private (CharacterEntity Player, ThumperEntity Thumper) ResolveTarget(CharacterEntity npc, BrainState brain, ulong currentTime)
+    {
+        // Keep the current target while the target is valid
+        if (brain.TargetEntityId != 0)
+        {
+            if (_shard.Entities.TryGetValue(brain.TargetEntityId, out var existing) && existing is ThumperEntity currentThumper)
+            {
+                if (currentThumper.IsAttackable)
+                {
+                    return (null, currentThumper);
+                }
+            }
+            else
+            {
+                // A player target stays in memory for a short time after it
+                // leaves the detection range
+                var current = FindPlayerById(brain.TargetEntityId);
+                if (current != null)
+                {
+                    var distance = Vector3.Distance(npc.Position, current.Position);
+                    if (distance <= brain.Profile.AggroRange)
+                    {
+                        brain.TargetLastSeenAt = currentTime;
+                    }
+
+                    if (currentTime - brain.TargetLastSeenAt <= TargetMemoryMs)
+                    {
+                        return (current, null);
+                    }
+                }
+            }
+
+            brain.TargetEntityId = 0;
+        }
+
+        var thumper = FindNearestAttackableThumper(npc, ThumperAggroRange);
+        var player = FindNearestPlayer(npc, brain.Profile.AggroRange);
+
+        // The default behavior prefers a player target. An attack on an
+        // objective, for example a thumper, usually comes from an order
+        // that the encounter gives.
+        if (thumper != null && player == null)
+        {
+            brain.TargetEntityId = thumper.EntityId;
+            _logger.Debug("NPC {NpcId} acquired thumper {TargetId}", npc.EntityId, thumper.EntityId);
+            return (null, thumper);
+        }
+
+        if (player != null)
+        {
+            brain.TargetEntityId = player.EntityId;
+            brain.TargetLastSeenAt = currentTime;
+            _logger.Debug("NPC {NpcId} acquired target {TargetId}", npc.EntityId, player.EntityId);
+        }
+
+        return (player, null);
+    }
+
+    /// <summary>Returns the nearest attackable thumper in the given range, or null.</summary>
+    private ThumperEntity FindNearestAttackableThumper(CharacterEntity npc, float range)
+    {
+        ThumperEntity nearest = null;
+        var nearestDistanceSq = range * range;
+
+        foreach (var entity in _shard.Entities.Values)
+        {
+            if (entity is not ThumperEntity thumper || !thumper.IsAttackable)
+            {
+                continue;
+            }
+
+            if (!IsHostileTowardFaction(GetNpcFactionId(npc), thumper.HostilityInfo.FactionId))
+            {
+                continue;
+            }
+
+            var distanceSq = Vector3.DistanceSquared(npc.Position, thumper.Position);
+            if (distanceSq < nearestDistanceSq)
+            {
+                nearest = thumper;
+                nearestDistanceSq = distanceSq;
+            }
+        }
+
+        return nearest;
+    }
+
+    /// <summary>
+    ///     Makes a melee strike against a thumper when the NPC is inside
+    ///     the contact range. The distance parameter is horizontal.
+    ///     PLACEHOLDER: the damage is a fixed integrity value. The
+    ///     DamageService will replace it.
+    /// </summary>
+    private void TryHitThumper(CharacterEntity npc, BrainState brain, ThumperEntity thumper, float distance, float contactRange, ulong currentTime)
+    {
+        // The 0.25 m tolerance is necessary. The movement code stops the
+        // NPC at the range boundary. An exact comparison can fail because
+        // of small float differences.
+        if (distance > contactRange + 0.25f || currentTime < brain.NextFireAt)
+        {
+            return;
+        }
+
+        thumper.Damage(ThumperDamagePerHit);
+        brain.NextFireAt = currentTime + ThumperHitCooldownMs;
+
+        // Send a visual projectile, so that the player can see the attack
+        if (brain.Profile.HasWeapon)
+        {
+            var aim = ComputeAttackAim(npc, thumper.Position);
+            if (aim != Vector3.Zero)
+            {
+                npc.SetAimDirection(aim);
+                AnnounceBurst(npc, aim);
+                _shard.WeaponSim.OnFireWeaponProjectile(npc, _shard.CurrentTime, aim);
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Fires the equipped weapon at a character target. Conditions: the
+    ///     NPC has a weapon, the cooldown is complete, the target is inside
+    ///     FireRange, and an aim solution exists. A melee weapon does not
+    ///     fire a projectile. It applies its damage directly.
+    /// </summary>
+    private void TryFire(CharacterEntity npc, BrainState brain, CharacterEntity target, float distance, ulong currentTime)
+    {
+        if (!brain.Profile.HasWeapon || distance > brain.Profile.FireRange || currentTime < brain.NextFireAt)
+        {
+            return;
+        }
+
+        // Aim at the torso of the target, not at its feet
+        var aim = ComputeAttackAim(npc, target.Position);
+        if (aim == Vector3.Zero)
+        {
+            return;
+        }
+
+        npc.SetAimDirection(aim);
+        AnnounceBurst(npc, aim);
+
+        // A melee strike applies its damage directly. The invisible contact
+        // projectile is not reliable at bite range. Its ray can start
+        // inside the hitbox of the target and then hits nothing. Ranged
+        // weapons use the simulated projectile.
+        // PLACEHOLDER: the damage value is fixed. Refer to
+        // codex/damage-design.md phase D1 for real weapon damage.
+        if (brain.Profile.PreferredRange <= 4f)
+        {
+            _shard.Damage.ApplyDamage(target, 1337, npc);
+        }
+        else
+        {
+            _shard.WeaponSim.OnFireWeaponProjectile(npc, _shard.CurrentTime, aim);
+        }
+
+        brain.NextFireAt = currentTime + brain.Profile.FireCooldownMs;
+    }
+
+    /// <summary>
+    ///     Computes the aim direction from the muzzle of the NPC to the
+    ///     torso of the target. For ammunition with gravity, the method
+    ///     computes a ballistic launch angle. It uses the low arc. When the
+    ///     target is out of ballistic range, it uses 45 degrees. For
+    ///     ammunition without gravity, it returns the direct line.
+    ///     A return value of zero means: do not fire.
+    /// </summary>
+    private Vector3 ComputeAttackAim(CharacterEntity npc, Vector3 targetPosition)
+    {
+        // Start the solution at the true muzzle height (the top of the rig
+        // capsule). A different start height makes the arc miss the target.
+        var origin = npc.Position + new Vector3(0f, 0f, npc.GetNpcMuzzleHeight());
+
+        // Aim at the torso. When the target stands above the NPC, aim at
+        // the head. The line to the torso of a target on a ledge touches
+        // the edge of the ledge. The shot then hits the terrain at the
+        // feet of the target.
+        var aimHeight = targetPosition.Z - npc.Position.Z > 1.5f ? 1.7f : 1f;
+        var target = targetPosition + new Vector3(0f, 0f, aimHeight);
+        var delta = target - origin;
+        var flat = SafeNormalize(delta);
+
+        var details = npc.GetActiveWeaponDetails();
+        if (details?.Weapon == null)
+        {
+            return flat;
+        }
+
+        var ammo = SDBInterface.GetAmmo(details.Weapon.AmmoId);
+        if (ammo == null || ammo.Gravity <= 0.01f || ammo.ProjectileSpeed <= 0.1f)
+        {
+            return flat;
+        }
+
+        // Only ammunition with the Parabolic simulation mode flies under
+        // gravity. Linear ammunition flies straight. Its gravity column has
+        // no effect. A ballistic solution for linear ammunition would fire
+        // the shot too high.
+        if (new Enums.AmmoFlags(ammo.Flags).Simulation != Enums.AmmoFlags.SimulationMode.Parabolic)
+        {
+            return flat;
+        }
+
+        var horizontal = MathF.Sqrt((delta.X * delta.X) + (delta.Y * delta.Y));
+        if (horizontal < 0.5f)
+        {
+            return flat;
+        }
+
+        // A test value from live reviews. It adds an up angle to ballistic aims.
+        const float AimPitchUpDeg = 0f;
+
+        Vector3 aim;
+        var g = ammo.Gravity;
+        var v2 = ammo.ProjectileSpeed * ammo.ProjectileSpeed;
+        var discriminant = (v2 * v2) - (g * ((g * horizontal * horizontal) + (2f * delta.Z * v2)));
+        if (discriminant <= 0f)
+        {
+            if (delta.Z > 2f)
+            {
+                // The target is higher than the ballistic reach. A maximum
+                // shot would only hit the cliff face. Do not fire. The
+                // movement code moves the NPC nearer. A shorter horizontal
+                // distance increases the height that the weapon can reach.
+                return Vector3.Zero;
+            }
+
+            // The target is out of ballistic range. An angle of 45 degrees
+            // gives the maximum reach.
+            aim = SafeNormalize(new Vector3(delta.X, delta.Y, horizontal));
+        }
+        else
+        {
+            // Artillery ammunition (a large splash radius) uses the high
+            // arc. The shot goes up and comes down near the target. The
+            // high arc is also correct when the target is far above the
+            // NPC. The low arc would touch the cliff edge or hit the cliff
+            // face. All other ammunition uses the low arc at level targets.
+            var isArtillery = ammo.ImpactRadius >= 3f || delta.Z > 4f;
+            var tanTheta = isArtillery
+                ? (v2 + MathF.Sqrt(discriminant)) / (g * horizontal)
+                : (v2 - MathF.Sqrt(discriminant)) / (g * horizontal);
+            aim = SafeNormalize(new Vector3(delta.X / horizontal, delta.Y / horizontal, tanTheta));
+
+            // An NPC behind a terrain edge fires the low arc into the
+            // ground at its feet. Examine the first meters of the shot
+            // line. If the line is blocked, use the high arc.
+            if (!isArtillery && IsMuzzleBlocked(npc, origin, aim))
+            {
+                var highTan = (v2 + MathF.Sqrt(discriminant)) / (g * horizontal);
+                aim = SafeNormalize(new Vector3(delta.X / horizontal, delta.Y / horizontal, highTan));
+            }
+        }
+
+        // Turn the aim up by AimPitchUpDeg. Limit the result to 85 degrees.
+        var horizLen = MathF.Sqrt((aim.X * aim.X) + (aim.Y * aim.Y));
+        if (horizLen > 0.001f)
+        {
+            var pitch = MathF.Atan2(aim.Z, horizLen) + (AimPitchUpDeg * MathF.PI / 180f);
+            pitch = MathF.Min(pitch, 85f * MathF.PI / 180f);
+            aim = SafeNormalize(new Vector3(aim.X / horizLen * MathF.Cos(pitch), aim.Y / horizLen * MathF.Cos(pitch), MathF.Sin(pitch)));
+        }
+
+        return aim;
+    }
+
+    /// <summary>Casts a short ray along the aim line. Returns true when terrain or an obstacle blocks the muzzle.</summary>
+    private bool IsMuzzleBlocked(CharacterEntity npc, Vector3 origin, Vector3 aim)
+    {
+        var hit = _shard.Physics.SegmentRayCast(origin, origin + (aim * 6f), npc.EntityId);
+        return hit.Hit;
+    }
+
+    // Sends the shot to the clients in scope. WeaponSim only feeds the
+    // server-side projectile simulation, which is not visible. The
+    // WeaponProjectileFired message uses the equipped weapon of the client
+    // and stays invisible for NPCs. Because of this, send the
+    // AbilityProjectileFired message. It names the ammunition directly and
+    // does not depend on client equipment data.
+    private void AnnounceBurst(CharacterEntity npc, Vector3 aim)
+    {
+        var time = (uint)_shard.CurrentTime;
+        npc.SetFireBurst(time);
+        npc.SetFireEnd(time + 1);
+
+        var details = npc.GetActiveWeaponDetails();
+        if (details?.Weapon == null)
+        {
+            return;
+        }
+
+        var range = details.Weapon.Range;
+        if (details.Attributes.TryGetValue((ushort)Enums.ItemAttributeId.WeaponRange, out var rangeAttr))
+        {
+            range = rangeAttr;
+        }
+
+        // The client applies the offset field of the packet in WORLD space
+        // (found in live tests). Turn the local offset (right, forward, up)
+        // to the direction of the shooter for each shot. The visual start
+        // point then follows the head of the model.
+        var flatAim = new Vector3(aim.X, aim.Y, 0f);
+        var flatLen = flatAim.Length();
+        var fxForward = flatLen > 0.001f ? flatAim / flatLen : Vector3.UnitY;
+        var fxRight = new Vector3(fxForward.Y, -fxForward.X, 0f);
+
+        // The offset values come from tests with the base aranha
+        // (scale 1.3). Scale the offset with the rig. A large creature then
+        // spits from its mouth, not from its legs.
+        var fxScale = (npc.Collision != null ? Math.Clamp(npc.Collision.Scale, 0.5f, 5f) : 1.3f) / 1.3f;
+        var fxOffset = ((fxRight * NpcFxOffset.X) + (fxForward * NpcFxOffset.Y) + new Vector3(0f, 0f, NpcFxOffset.Z)) * fxScale;
+
+        var fired = new AbilityProjectileFired
+        {
+            ShortTime = (ushort)time,
+            MaybeHalfs = fxOffset,
+            Aim = aim,
+            AmmoType = (ushort)details.Weapon.AmmoId,
+            Range = range,
+            Unk1 = 0,
+            Unk2 = 1,
+            Unk3 = 0,
+            Unk4 = 0,
+            Unk5 = 0,
+            Hardpoint = NpcFxHardpoint,
+            UnkFlag = 0,
+        };
+        _shard.EntityMan.SendToScoped(npc, fired);
+    }
+
+    /// <summary>
+    ///     Derives the behavior profile for a character type and caches it.
+    ///     All data comes from the SDB. There are no configuration files
+    ///     for each monster. The monster row gives the speeds and the
+    ///     faction. The rig name gives the movement class. The weapon
+    ///     ranges give the combat style. The behavior strings give extra
+    ///     tunable values.
+    /// </summary>
+    private AiProfile GetProfile(CharacterEntity npc)
+    {
+        var typeId = npc.StaticInfo.CharacterTypeId;
+        return _profiles.GetOrAdd(typeId, id =>
+        {
+            var profile = new AiProfile
+            {
+                Aggressive = false,
+                AggroRange = DefaultAggroRange,
+                NormalSpeed = DefaultNormalSpeed,
+                FastSpeed = DefaultFastSpeed,
+                HasWeapon = false,
+                FireCooldownMs = DefaultTriggerPullMs + DefaultFireRestMs,
+                PreferredRange = RangedHoldRange,
+                FireRange = 40f,
+            };
+
+            var monster = id != 0 ? SDBInterface.GetMonster(id) : null;
+            if (monster == null)
+            {
+                return profile;
+            }
+
+            profile.Aggressive = IsHostileTowardPlayers(monster.FactionId);
+            profile.NormalSpeed = ClampSpeed(monster.NormalSpeed, DefaultNormalSpeed);
+            profile.FastSpeed = ClampSpeed(monster.FastSpeed, DefaultFastSpeed);
+            profile.HasWeapon = monster.Weapon1Id != 0 || monster.Weapon2Id != 0;
+
+            // The rig name in CharInfo gives the movement class. The SDB
+            // has no flag column for this. Examples of flyer rig names:
+            // "Mosquito", "Drone", "Flying Roach", "Hovering", "UAV".
+            // Turret rigs and tower rigs never move.
+            var rigName = (monster.CharinfoId != 0 ? SDBInterface.GetCharInfo(monster.CharinfoId)?.Name : null) ?? string.Empty;
+            profile.Flying = ContainsAny(rigName, "drone", "mosquito", "flying", "hovering", "uav");
+            profile.Stationary = ContainsAny(rigName, "turret", "tower", "thumper", "spawner", "tentacle", "inhibitor");
+            profile.CanClimb = ContainsAny(rigName, "climber", "aranha", "spider")
+                && !rigName.Contains("Non Climbing", StringComparison.OrdinalIgnoreCase);
+
+            // The combat style sets the hold distance. The reach comes from
+            // the real weapon data. Example: the aranha bite is a weapon
+            // with a 3.12 m range. An aranha that holds a ranged distance
+            // can never attack. The behavior tokens cover monsters that
+            // have no weapon rows. 45 monster types have a melee weapon and
+            // a ranged weapon. Classify these by the longer weapon. They
+            // then fight at range. Weapon change at short range is a
+            // Phase B feature. HasMeleeBackup marks these monsters.
+            var range1 = monster.Weapon1Id != 0 ? SDBUtils.GetDetailedWeaponInfo(monster.Weapon1Id)?.Main?.Range ?? 0f : 0f;
+            var range2 = monster.Weapon2Id != 0 ? SDBUtils.GetDetailedWeaponInfo(monster.Weapon2Id)?.Main?.Range ?? 0f : 0f;
+            var weaponRange = Math.Max(range1, range2);
+            var shortest = Math.Min(range1 > 0f ? range1 : float.MaxValue, range2 > 0f ? range2 : float.MaxValue);
+            profile.HasMeleeBackup = shortest <= 6f && weaponRange > 6f;
+
+            // A new NPC has weapon slot 1 equipped. When slot 2 has the
+            // longer weapon, the brain changes to slot 2 on its first think.
+            profile.PreferredWeaponIndex = (byte)(range2 > range1 && range2 > 0f ? 2 : 0);
+
+            var archetypes = $"{monster.Behavior} {monster.BehaviorOffensive} {monster.BehaviorDefensive}";
+            var isMelee = (weaponRange > 0f && weaponRange <= 6f)
+                || ContainsAny(archetypes, "melee", "kamikaze", "charger", "whipper", "brute", "rageclaw", "scorcher")
+                || (!profile.HasWeapon && !ContainsAny(archetypes, "ranged", "sniper", "movethenfire"));
+            if (isMelee)
+            {
+                // Stop outside the body of the target, but inside the attack reach
+                profile.PreferredRange = weaponRange > 0f
+                    ? Math.Clamp(weaponRange - 0.5f, 1.5f, 3f)
+                    : MeleeRange;
+                profile.FireRange = weaponRange > 0f ? weaponRange + 0.25f : 4f;
+            }
+            else
+            {
+                profile.PreferredRange = ContainsAny(archetypes, "sniper") ? SniperHoldRange : RangedHoldRange;
+                if (weaponRange > 0f && weaponRange < profile.PreferredRange)
+                {
+                    profile.PreferredRange = Math.Max(4f, weaponRange * 0.8f);
+                }
+
+                profile.FireRange = weaponRange > 0f
+                    ? Math.Min(weaponRange, profile.PreferredRange + 22f)
+                    : profile.PreferredRange + 22f;
+
+                // An artillery type (ammunition with a large splash radius)
+                // holds a position near its maximum weapon range. The
+                // default hold distance is too near. At 18 m, the splash
+                // damage of the NPC can hit the NPC itself.
+                var classifiedWeapon = range2 > range1 ? monster.Weapon2Id : monster.Weapon1Id;
+                var mainTemplate = classifiedWeapon != 0 ? SDBUtils.GetDetailedWeaponInfo(classifiedWeapon)?.Main : null;
+                var ammoRecord = mainTemplate != null ? SDBInterface.GetAmmo(mainTemplate.AmmoId) : null;
+                if (ammoRecord is { ImpactRadius: >= 3f } && weaponRange > 8f)
+                {
+                    profile.PreferredRange = Math.Max(profile.PreferredRange, weaponRange - 4f);
+                    profile.FireRange = weaponRange;
+                }
+            }
+
+            ApplyBehaviorTunables(profile, monster);
+            return profile;
+        });
+    }
+
+    /// <summary>Applies the key=value tunables from the behavior strings of the monster. Example: fire timing values.</summary>
+    private void ApplyBehaviorTunables(AiProfile profile, Monster monster)
+    {
+        uint triggerPull = DefaultTriggerPullMs;
+        uint fireRest = DefaultFireRestMs;
+
+        foreach (var behavior in new[] { monster.Behavior, monster.BehaviorOffensive, monster.BehaviorDefensive })
+        {
+            if (string.IsNullOrWhiteSpace(behavior))
+            {
+                continue;
+            }
+
+            foreach (Match match in BehaviorParamRegex.Matches(behavior))
+            {
+                var key = match.Groups["key"].Value;
+                if (!float.TryParse(match.Groups["value"].Value, System.Globalization.CultureInfo.InvariantCulture, out var value))
+                {
+                    continue;
+                }
+
+                switch (key)
+                {
+                    case "targetSelectDist":
+                        profile.AggroRange = Math.Clamp(value, 5f, 150f);
+                        break;
+                    case "triggerPullTime":
+                        triggerPull = (uint)Math.Clamp(value, 100f, 10000f);
+                        break;
+                    case "fireRestDuration":
+                        fireRest = (uint)Math.Clamp(value, 0f, 10000f);
+                        break;
+                }
+            }
+        }
+
+        profile.FireCooldownMs = triggerPull + fireRest;
+    }
+
+    /// <summary>Reads the faction stance from the SDB faction matrix. A negative stance means hostile. The matrix loads on first use.</summary>
+    private bool IsHostileTowardFaction(uint factionA, uint factionB)
+    {
+        EnsureFactionData();
+
+        if (factionA == 0 || factionA == factionB)
+        {
+            return false;
+        }
+
+        if (_factionStance.TryGetValue((factionA, factionB), out var stance))
+        {
+            return stance < 0;
+        }
+
+        return _factionDefaultStance.GetValueOrDefault(factionA, (sbyte)0) < 0;
+    }
+
+    private uint GetNpcFactionId(CharacterEntity npc)
+    {
+        return npc.HostilityInfo.Flags.HasFlag(AeroMessages.GSS.HostilityInfoData.HostilityFlags.Faction)
+            ? npc.HostilityInfo.FactionId
+            : 0u;
+    }
+
+    private void EnsureFactionData()
+    {
+        if (_factionStance != null)
+        {
+            return;
+        }
+
+        var stance = new Dictionary<(uint, uint), sbyte>();
+        foreach (var relation in SDBInterface.GetFactionRelations())
+        {
+            stance[(relation.FactionA, relation.FactionB)] = relation.HostilityStance;
+            if (relation.HostilityBidirectional != 0)
+            {
+                stance[(relation.FactionB, relation.FactionA)] = relation.HostilityStance;
+            }
+        }
+
+        _factionDefaultStance = SDBInterface.GetFactions().ToDictionary(f => f.Id, f => f.DefaultStance);
+        _factionStance = stance;
+    }
+
+    /// <summary>Sends the pose to the clients, at most one time for each think interval. Network broadcasts are costly.</summary>
+    private void BroadcastPoseIfDue(CharacterEntity npc, BrainState brain, ulong currentTime)
+    {
+        if (currentTime >= brain.NextPoseBroadcastAt)
+        {
+            _shard.Movement.BroadcastCharacterPose(npc);
+            brain.NextPoseBroadcastAt = currentTime + ThinkIntervalMs;
+        }
+    }
+
+    private CharacterEntity FindPlayerById(ulong entityId)
+    {
+        foreach (var client in _shard.Clients.Values)
+        {
+            var candidate = client.CharacterEntity;
+            if (candidate != null
+                && candidate.EntityId == entityId
+                && client.Status == IPlayer.PlayerStatus.Playing
+                && IsLiving(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
+    private CharacterEntity FindNearestPlayer(CharacterEntity npc, float range, Vector3? center = null)
+    {
+        CharacterEntity nearest = null;
+        var nearestDistanceSq = range * range;
+        var origin = center ?? npc.Position;
+
+        foreach (var client in _shard.Clients.Values)
+        {
+            var candidate = client.CharacterEntity;
+            if (client.Status != IPlayer.PlayerStatus.Playing || candidate == null || !IsLiving(candidate))
+            {
+                continue;
+            }
+
+            var distanceSq = Vector3.DistanceSquared(origin, candidate.Position);
+            if (distanceSq < nearestDistanceSq)
+            {
+                nearest = candidate;
+                nearestDistanceSq = distanceSq;
+            }
+        }
+
+        return nearest;
+    }
+
+    private bool IsLiving(CharacterEntity character)
+    {
+        return character.CharacterState.State == CharacterStateData.CharacterStatus.Living;
+    }
+
+    private Vector3 SafeNormalize(Vector3 value)
+    {
+        return value.LengthSquared() > 0.0001f ? Vector3.Normalize(value) : Vector3.Zero;
+    }
+
+    private float ClampSpeed(float value, float fallback)
+    {
+        return value > 0.1f ? Math.Clamp(value, 1f, 15f) : fallback;
+    }
+
+    /// <summary>Writes the aim, the orientation, the movement state, and the position (optional) to the replicated character.</summary>
+    private void SetMovement(CharacterEntity character, Vector3 aimDirection, short movementState, Vector3? position = null)
+    {
+        if (aimDirection != Vector3.Zero)
+        {
+            character.SetAimDirection(aimDirection);
+
+            // The replicated orientation is the world-to-local rotation.
+            // The local +Y axis is the forward direction. Refer to
+            // CalculateProjectileOrigin: local offsets go to world space
+            // through the INVERSE quaternion, and the muzzle offset is
+            // local (right, forward, up). The yaw angle is measured from
+            // +Y. The wire format wants the inverse rotation. These two
+            // facts together give Atan2(X, Y). The earlier Atan2(Y, X)
+            // turned NPCs to the side or to the back.
+            character.SetOrientation(Quaternion.CreateFromAxisAngle(Vector3.UnitZ, MathF.Atan2(aimDirection.X, aimDirection.Y)));
+        }
+
+        character.MovementStateContainer.MovementStateValue = (ushort)movementState;
+        character.MovementState = movementState;
+        character.MovementShortTime = character.Shard.CurrentShortTime;
+
+        if (position.HasValue)
+        {
+            character.SetPosition(position.Value);
+        }
+    }
+
+    /// <summary>
+    ///     The mutable state of one brain. It is created on the first think
+    ///     of the entity. It is removed when the entity dies or despawns.
+    ///     The leap and perch fields belong to the leap attacks and the
+    ///     hull climbing in AIEngine.Aranha.cs.
+    /// </summary>
+    private class BrainState
+    {
+        public Vector3 Home { get; set; }                       // The spawn position. The leash and the return use it.
+        public AiProfile Profile { get; set; }                  // The shared profile of the type. Do not change it.
+        public BrainMode Mode { get; set; }
+        public ulong TargetEntityId { get; set; }
+        public ulong TargetLastSeenAt { get; set; }             // The time of the last target contact. TargetMemoryMs uses it.
+        public ulong NextFireAt { get; set; }
+        public ulong NextPoseBroadcastAt { get; set; }          // The time of the next permitted pose broadcast.
+        public bool WeaponAligned { get; set; }                 // True after the one-time weapon-slot change on the first think.
+        public float BodyRadius { get; set; } = 0.5f;           // The radius of the separation disc. ApplySeparation uses it.
+
+        // An active leap (a pounce at a player, or a leap onto a hull)
+        public Vector3 LeapStart { get; set; }
+        public Vector3 LeapTarget { get; set; }
+        public ulong LeapWalkableId { get; set; }               // The entity that is the landing surface. Zero means the ground.
+        public ulong LeapStartedAt { get; set; }
+        public ulong LeapEndsAt { get; set; }                   // While this is in the future, only TickLeap controls the NPC.
+        public ulong NextPounceAt { get; set; }                 // The time when the next leap is permitted.
+
+        // The NPC holds a perch point on a climbable hull
+        public bool HasPerch { get; set; }
+        public Vector3 PerchOffset { get; set; }                // The perch position, relative to the hull entity.
+    }
+
+    /// <summary>
+    ///     The behavior profile of one character type. GetProfile derives
+    ///     it from SDB data one time and caches it. All instances of the
+    ///     type share one profile object. Do not change a profile after
+    ///     its creation.
+    /// </summary>
+    private class AiProfile
+    {
+        public bool Aggressive { get; set; }                    // True when the type is hostile to players.
+        public float AggroRange { get; set; }
+        public float NormalSpeed { get; set; }                  // The walk speed in m/s.
+        public float FastSpeed { get; set; }                    // The chase speed in m/s.
+        public bool HasWeapon { get; set; }
+        public uint FireCooldownMs { get; set; }
+        public bool Flying { get; set; }                        // Movement class: the NPC flies in 3D to a hover point.
+        public bool Stationary { get; set; }                    // Movement class: the NPC aims but does not move.
+        public bool CanClimb { get; set; }                      // Movement class: hulls are walkable surfaces for the NPC.
+        public float PreferredRange { get; set; } = RangedHoldRange;  // The hold distance: melee 2, ranged 18, sniper 38.
+        public float FireRange { get; set; } = 40f;             // The maximum firing distance.
+        public bool HasMeleeBackup { get; set; }                // True for types with a melee weapon and a ranged weapon.
+        public byte PreferredWeaponIndex { get; set; }          // The weapon slot that sets the combat style.
     }
 }
+

--- a/UdpHosts/GameServer/Entities/Character/CharacterEntity.cs
+++ b/UdpHosts/GameServer/Entities/Character/CharacterEntity.cs
@@ -1219,6 +1219,23 @@ public sealed partial class CharacterEntity : BaseAptitudeEntity, IAptitudeTarge
         return GetProjectileOrigin(AimDirection);
     }
 
+    /// <summary>
+    ///     Returns the muzzle height for NPC projectiles. It is the top of
+    ///     the scaled physics capsule of the rig. The AIEngine value
+    ///     NpcMuzzleFraction adjusts it.
+    /// </summary>
+    public float GetNpcMuzzleHeight()
+    {
+        var height = 1.62f;
+        if (Collision is CharacterCollisionComponent { PoseTypeRecord: not null } collision
+            && collision.PoseTypeRecord.PhysicsHeight > 0.1f)
+        {
+            height = collision.PoseTypeRecord.PhysicsHeight * Math.Max(collision.Scale, 0.1f);
+        }
+
+        return Math.Clamp(height * AIEngine.NpcMuzzleFraction, 0.3f, 4f);
+    }
+
     public Vector3 GetProjectileOrigin(Vector3 aimDirection)
     {
         return CalculateProjectileOrigin(Position, Orientation, IsCrouching, aimDirection);

--- a/UdpHosts/GameServer/Entities/Thumper/ThumperEntity.cs
+++ b/UdpHosts/GameServer/Entities/Thumper/ThumperEntity.cs
@@ -28,7 +28,8 @@ public sealed class ThumperEntity : BaseAptitudeEntity, IAptitudeTarget
         LandedAbility = commandDef.LandedAbility;
         CompletedAbility = commandDef.CompletedAbility;
         CalldownTimeMs = commandDef.CalldownTimeMs;
-        MaxHealth = (uint)commandDef.Health;
+        MaxHealth = commandDef.Health > 0 ? (uint)commandDef.Health : 5000;
+        CurrentHealth = MaxHealth;
         Interaction = new InteractionComponent()
           {
               Type = InteractionType.GenericHold,
@@ -59,6 +60,18 @@ public sealed class ThumperEntity : BaseAptitudeEntity, IAptitudeTarget
     public uint CompletedAbility { get; set; }
     public uint CalldownTimeMs { get; set; }
     public uint MaxHealth { get; set; }
+
+    public uint CurrentHealth { get; private set; }
+
+    /// <summary>True when the health of the thumper is zero.</summary>
+    public bool IsDestroyed => CurrentHealth == 0;
+
+    /// <summary>
+    ///     True when NPCs can attack the thumper: it has health, and its
+    ///     state is between warm-up and departure.
+    /// </summary>
+    public bool IsAttackable => CurrentHealth > 0
+        && StateInfo.State is >= (byte)ThumperState.WARMINGUP and < (byte)ThumperState.LEAVING;
 
     public ushort StatusEffectsChangeTime_0 { get; set; }
     public ushort StatusEffectsChangeTime_1 { get; set; }
@@ -161,6 +174,26 @@ public sealed class ThumperEntity : BaseAptitudeEntity, IAptitudeTarget
     {
         HostilityInfo = newValue;
         ResourceNode_ObserverView?.HostilityInfoProp = HostilityInfo;
+    }
+
+    /// <summary>
+    ///     Decreases the thumper health. At zero health, the thumper goes
+    ///     to the DESTROYED state.
+    /// </summary>
+    public void Damage(uint amount)
+    {
+        if (IsDestroyed)
+        {
+            return;
+        }
+
+        CurrentHealth = amount >= CurrentHealth ? 0 : CurrentHealth - amount;
+        ResourceNode_ObserverView.CurrentHealthPctProp = (byte)(CurrentHealth * 100 / MaxHealth);
+
+        if (IsDestroyed)
+        {
+            TransitionToState(ThumperState.DESTROYED);
+        }
     }
 
     public void TransitionToState(ThumperState newState)

--- a/UdpHosts/GameServer/IShard.cs
+++ b/UdpHosts/GameServer/IShard.cs
@@ -32,6 +32,9 @@ public interface IShard : IPacketSender
     MovementRelay Movement { get; }
     EntityManager EntityMan { get; }
     EncounterManager EncounterMan { get; }
+
+    /// <summary>Authored hive sites for the wave-eruption behavior of the thumper encounter.</summary>
+    Systems.World.HiveIndex Hives { get; }
     AbilitySystem Abilities { get; }
     ProjectileSim ProjectileSim { get; }
     WeaponSim WeaponSim { get; }

--- a/UdpHosts/GameServer/Physics/PhysicsEngine.cs
+++ b/UdpHosts/GameServer/Physics/PhysicsEngine.cs
@@ -314,7 +314,13 @@ public partial class PhysicsEngine
             hitResult.Normal = hitHandler.Normal;
             hitResult.ChildIndex = hitHandler.ChildIndex;
             hitResult.Collidable = hitHandler.HitCollidable;
-            hitResult.HitEntityId = _bodyToEntityId.GetValueOrDefault(hitHandler.HitCollidable.BodyHandle);
+
+            // Only a body-owned collidable has a body handle. A read on a
+            // static collidable (zone terrain, with LoadMapsCollision on)
+            // stops the process with a Bepu assertion.
+            hitResult.HitEntityId = hitHandler.HitCollidable.Mobility != CollidableMobility.Static
+                ? _bodyToEntityId.GetValueOrDefault(hitHandler.HitCollidable.BodyHandle)
+                : 0;
         }
 
         return hitResult;

--- a/UdpHosts/GameServer/Physics/PhysicsEngine.cs
+++ b/UdpHosts/GameServer/Physics/PhysicsEngine.cs
@@ -253,6 +253,41 @@ public partial class PhysicsEngine
         });
     }
 
+    /// <summary>
+    ///     Probes the static zone geometry straight down and returns the
+    ///     ground height at a position. Kinematic bodies (characters,
+    ///     deployables) are ignored, so that an NPC below the probe cannot
+    ///     appear as terrain. Returns null when the probe hits no static
+    ///     geometry (zone collision not loaded, or outside the mesh).
+    /// </summary>
+    /// <param name="position">The probe position. X and Y select the column; Z is the reference height.</param>
+    /// <param name="walkableEntityId">Optional. The surface of this kinematic entity also counts as ground. A climber can then walk on the hull of the entity.</param>
+    /// <param name="probeUp">The probe start height above the position, in meters.</param>
+    /// <param name="probeDown">The probe depth below the start, in meters.</param>
+    public float? GetGroundHeight(Vector3 position, ulong walkableEntityId = 0, float probeUp = 40f, float probeDown = 120f)
+    {
+        var from = position + new Vector3(0f, 0f, probeUp);
+        var distance = probeUp + probeDown;
+
+        var hitHandler = default(RayHitHandler);
+        hitHandler.T = distance;
+        hitHandler.StaticsOnly = true;
+        if (walkableEntityId != 0 && _entityIdToBody.TryGetValue(walkableEntityId, out var walkableBody))
+        {
+            hitHandler.HasWalkableBody = true;
+            hitHandler.WalkableBody = walkableBody;
+        }
+
+        Simulation.RayCast(from, new Vector3(0f, 0f, -1f), distance, BufferPool, ref hitHandler);
+
+        if (hitHandler.T < distance)
+        {
+            return from.Z - hitHandler.T;
+        }
+
+        return null;
+    }
+
     public SegmentRaycastHit SegmentRayCast(Vector3 from, Vector3 to, ulong ignoreEntityId)
     {
         var hitResult = default(SegmentRaycastHit);
@@ -371,6 +406,9 @@ public partial class PhysicsEngine
         public float T;
         public CollidableReference HitCollidable;
         public bool AvoidSourceBody;
+        public bool StaticsOnly;
+        public bool HasWalkableBody;
+        public BodyHandle WalkableBody;
         public BodyHandle SourceBody;
         public Vector3 Normal;
         public int ChildIndex;
@@ -378,6 +416,13 @@ public partial class PhysicsEngine
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public readonly bool AllowTest(CollidableReference collidable)
         {
+            // StaticsOnly accepts static geometry, plus one optional walkable body
+            if (StaticsOnly && collidable.Mobility != CollidableMobility.Static
+                && !(HasWalkableBody && collidable.BodyHandle.Equals(WalkableBody)))
+            {
+                return false;
+            }
+
             if (AvoidSourceBody && collidable.Mobility != CollidableMobility.Static && collidable.BodyHandle.Equals(SourceBody))
             {
                 return false;
@@ -389,6 +434,12 @@ public partial class PhysicsEngine
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public readonly bool AllowTest(CollidableReference collidable, int childIndex)
         {
+            if (StaticsOnly && collidable.Mobility != CollidableMobility.Static
+                && !(HasWalkableBody && collidable.BodyHandle.Equals(WalkableBody)))
+            {
+                return false;
+            }
+
             if (AvoidSourceBody && collidable.Mobility != CollidableMobility.Static && collidable.BodyHandle.Equals(SourceBody))
             {
                 return false;

--- a/UdpHosts/GameServer/Shard.cs
+++ b/UdpHosts/GameServer/Shard.cs
@@ -47,7 +47,7 @@ public class Shard : IShard
         EventBus = new EventBus();
         var debugCallbacks = new DebugProjectileHitCallbacks(this);
         Physics = new PhysicsEngine(EventBus, Settings.ZoneId, Settings.MapsPath, Settings.AssetDBPath, Settings.LoadMapsCollision, debugCallbacks, false, Settings.CachePath, Settings.ForceReloadZone);
-        AI = new AIEngine();
+        AI = new AIEngine(this);
         Movement = new MovementRelay(this);
         Abilities = new AbilitySystem(this);
         EntityMan = new EntityManager(this);

--- a/UdpHosts/GameServer/Shard.cs
+++ b/UdpHosts/GameServer/Shard.cs
@@ -52,6 +52,9 @@ public class Shard : IShard
         Abilities = new AbilitySystem(this);
         EntityMan = new EntityManager(this);
         EncounterMan = new EncounterManager(this);
+        Hives = new Systems.World.HiveIndex(
+            string.IsNullOrWhiteSpace(Settings.CachePath) ? "runtime-data" : Settings.CachePath,
+            Settings.ZoneId);
         WeaponSim = new WeaponSim(this);
         ProjectileSim = new ProjectileSim(this, debugCallbacks);
         Chat = new ChatService(this, EventBus);
@@ -75,6 +78,8 @@ public class Shard : IShard
     public MovementRelay Movement { get; }
     public EntityManager EntityMan { get; }
     public EncounterManager EncounterMan { get; }
+
+    public Systems.World.HiveIndex Hives { get; }
     public AbilitySystem Abilities { get; }
     public ProjectileSim ProjectileSim { get; }
     public WeaponSim WeaponSim { get; }

--- a/UdpHosts/GameServer/Systems/Admin/Commands/HiveServerCommand.cs
+++ b/UdpHosts/GameServer/Systems/Admin/Commands/HiveServerCommand.cs
@@ -1,0 +1,75 @@
+using System.Globalization;
+using System.Text;
+using GameServer.Systems.World;
+
+namespace GameServer.Systems.Admin.Commands;
+
+[ServerCommand("Manage aranha hive sites (burrowed population woken by thumping)", "hive add [radius] [burst] | hive list | hive clear", "hive")]
+public class HiveServerCommand : ServerCommand
+{
+    public override void Execute(string[] parameters, ServerCommandContext context)
+    {
+        var character = context.SourcePlayer?.CharacterEntity;
+        if (character == null)
+        {
+            SourceFeedback("Requires a player character", context);
+            return;
+        }
+
+        var shard = character.Shard;
+        var sub = parameters.Length > 0 ? parameters[0].ToLowerInvariant() : "list";
+
+        switch (sub)
+        {
+            case "add":
+            {
+                var radius = 120f;
+                var burst = 50;
+                if (parameters.Length > 1 && float.TryParse(parameters[1], NumberStyles.Float, CultureInfo.InvariantCulture, out var r))
+                {
+                    radius = r;
+                }
+
+                if (parameters.Length > 2 && int.TryParse(parameters[2], out var b))
+                {
+                    burst = b;
+                }
+
+                var position = character.Position;
+                var name = $"hive-{shard.Hives.Sites.Count + 1}";
+                shard.Hives.Add(new HiveSite(name, position.X, position.Y, position.Z, radius, burst));
+                SourceFeedback($"Hive '{name}' planted at ({position.X:0},{position.Y:0},{position.Z:0}) radius {radius:0}m burst {burst}. Thump nearby to wake it.", context);
+                break;
+            }
+
+            case "clear":
+            {
+                var removed = shard.Hives.Clear();
+                SourceFeedback($"Removed {removed} hive sites.", context);
+                break;
+            }
+
+            default:
+            {
+                var sites = shard.Hives.Sites;
+                if (sites.Count == 0)
+                {
+                    SourceFeedback("No hive sites. Use: hive add [radius] [burst]", context);
+                    return;
+                }
+
+                var sb = new StringBuilder($"{sites.Count} hive sites:\n");
+                foreach (var site in sites)
+                {
+                    var dx = character.Position.X - site.X;
+                    var dy = character.Position.Y - site.Y;
+                    var distance = System.MathF.Sqrt((dx * dx) + (dy * dy));
+                    sb.AppendLine($"  {site.Name}: ({site.X:0},{site.Y:0}) r={site.Radius:0} burst={site.Burst} — {distance:0}m from you");
+                }
+
+                SourceFeedback(sb.ToString(), context);
+                break;
+            }
+        }
+    }
+}

--- a/UdpHosts/GameServer/Systems/Admin/Commands/NpcFxServerCommand.cs
+++ b/UdpHosts/GameServer/Systems/Admin/Commands/NpcFxServerCommand.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Globalization;
+using System.Numerics;
+
+namespace GameServer.Systems.Admin.Commands;
+
+[ServerCommand("Live-tune NPC projectile FX: muzzle height fraction of the rig capsule, client hardpoint id, and the AbilityProjectileFired half-vector field.", "npcfx show | npcfx muzzle <fraction> | npcfx hardpoint <id> | npcfx offset <x> <y> <z>", "npcfx", "npc_fx")]
+public class NpcFxServerCommand : ServerCommand
+{
+    public override void Execute(string[] parameters, ServerCommandContext context)
+    {
+        if (parameters.Length == 0 || string.Equals(parameters[0], "show", StringComparison.OrdinalIgnoreCase))
+        {
+            var aimPoint = AIEngine.NpcAimPointOverride?.ToString() ?? "off";
+            SourceFeedback($"npcfx: muzzle={AIEngine.NpcMuzzleFraction.ToString(CultureInfo.InvariantCulture)} hardpoint={AIEngine.NpcFxHardpoint} offset={AIEngine.NpcFxOffset} aimpoint={aimPoint}", context);
+            return;
+        }
+
+        switch (parameters[0].ToLowerInvariant())
+        {
+            case "muzzle" when parameters.Length == 2 && float.TryParse(parameters[1], NumberStyles.Float, CultureInfo.InvariantCulture, out var fraction):
+                AIEngine.NpcMuzzleFraction = Math.Clamp(fraction, 0f, 3f);
+                SourceFeedback($"npcfx muzzle fraction = {AIEngine.NpcMuzzleFraction}", context);
+                break;
+            case "hardpoint" when parameters.Length == 2 && uint.TryParse(parameters[1], out var hardpoint):
+                AIEngine.NpcFxHardpoint = hardpoint;
+                SourceFeedback($"npcfx hardpoint = {hardpoint}", context);
+                break;
+            case "resetprofiles":
+                var cleared = context.Shard.AI.ClearProfiles();
+                SourceFeedback($"npcfx: cleared {cleared} cached AI profiles (live brains rebuild next tick)", context);
+                break;
+            case "aimpoint" when parameters.Length == 2 && string.Equals(parameters[1], "clear", StringComparison.OrdinalIgnoreCase):
+                AIEngine.NpcAimPointOverride = null;
+                SourceFeedback("npcfx aimpoint cleared - NPCs hunt live targets again", context);
+                break;
+            case "aimpoint" when parameters.Length == 2 && string.Equals(parameters[1], "here", StringComparison.OrdinalIgnoreCase):
+                if (context.SourcePlayer?.CharacterEntity == null)
+                {
+                    SourceFeedback("No player character to take a position from", context);
+                    return;
+                }
+
+                AIEngine.NpcAimPointOverride = context.SourcePlayer.CharacterEntity.Position;
+                SourceFeedback($"npcfx aimpoint = {AIEngine.NpcAimPointOverride} (your current spot - now step aside)", context);
+                break;
+            case "aimpoint" when parameters.Length == 4:
+                Vector3? point = ParseVector3Parameters(parameters, 1);
+                if (point == null)
+                {
+                    SourceFeedback("Failed to parse aim point", context);
+                    return;
+                }
+
+                AIEngine.NpcAimPointOverride = point;
+                SourceFeedback($"npcfx aimpoint = {point}", context);
+                break;
+            case "offset" when parameters.Length == 4:
+                Vector3? offset = ParseVector3Parameters(parameters, 1);
+                if (offset == null)
+                {
+                    SourceFeedback("Failed to parse offset vector", context);
+                    return;
+                }
+
+                AIEngine.NpcFxOffset = (Vector3)offset;
+                SourceFeedback($"npcfx offset = {AIEngine.NpcFxOffset}", context);
+                break;
+            default:
+                SourceFeedback("Usage: npcfx show | npcfx muzzle <fraction> | npcfx hardpoint <id> | npcfx offset <x> <y> <z>", context);
+                break;
+        }
+    }
+}

--- a/UdpHosts/GameServer/Systems/Admin/Commands/PacifyServerCommand.cs
+++ b/UdpHosts/GameServer/Systems/Admin/Commands/PacifyServerCommand.cs
@@ -1,0 +1,47 @@
+using System;
+
+namespace GameServer.Systems.Admin.Commands;
+
+[ServerCommand("Toggle NPC aggression: pacify the admin target, or every live NPC with 'all'.", "pacify <on|off> [all]", "pacify", "passive", "calm")]
+public class PacifyServerCommand : ServerCommand
+{
+    public override void Execute(string[] parameters, ServerCommandContext context)
+    {
+        if (parameters.Length is < 1 or > 2)
+        {
+            SourceFeedback("Usage: pacify <on|off> [all]", context);
+            return;
+        }
+
+        bool passive;
+        if (string.Equals(parameters[0], "on", StringComparison.OrdinalIgnoreCase))
+        {
+            passive = true;
+        }
+        else if (string.Equals(parameters[0], "off", StringComparison.OrdinalIgnoreCase))
+        {
+            passive = false;
+        }
+        else
+        {
+            SourceFeedback("Usage: pacify <on|off> [all]", context);
+            return;
+        }
+
+        if (parameters.Length == 2 && string.Equals(parameters[1], "all", StringComparison.OrdinalIgnoreCase))
+        {
+            var count = context.Shard.AI.SetAllPassive(passive);
+            SourceFeedback($"Pacify {(passive ? "on" : "off")} for {count} NPC brains", context);
+            return;
+        }
+
+        if (context.Target == null)
+        {
+            SourceFeedback("No admin target set - use 'target <entityId/name>' first, or 'pacify <on|off> all'", context);
+            return;
+        }
+
+        context.Shard.AI.SetPassive(context.Target.EntityId, passive);
+        SourceFeedback($"Pacify {(passive ? "on" : "off")} for 0x{context.Target.EntityId:x16}", context);
+    }
+}

--- a/UdpHosts/GameServer/Systems/Encounters/Encounters/Thumper.cs
+++ b/UdpHosts/GameServer/Systems/Encounters/Encounters/Thumper.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Numerics;
 using GameServer.Entities;
 using GameServer.Entities.Thumper;
 using GameServer.Enums;
@@ -7,9 +9,35 @@ namespace GameServer.Systems.Encounters.Encounters;
 
 public class Thumper : BaseEncounter, IInteractionHandler
 {
+    // Wave tuning. These constants control the attack pressure. A thumper
+    // without defenders must survive a full cycle with damage, but it must
+    // not die.
+    private const uint FirstWaveDelayMs = 10_000;
+    private const uint WaveIntervalMs = 30_000;
+    private const int MaxAliveAttackers = 8;
+    private const float SpawnRadiusMin = 25f;
+    private const float SpawnRadiusMax = 35f;
+
+    // Hive eruption. Aranhas stay below the ground until seismic activity
+    // wakes them. A thumper inside an authored hive site (admin command
+    // "hive add") replaces the small default waves with a dense and fast
+    // eruption. The distance to the hive center controls the strength.
+    private const uint HiveWaveIntervalMs = 8_000;
+    private const uint HiveFirstWaveDelayMs = 3_000;
+    private const int HiveMaxWaveSize = 16;
+
+    // Armed wildlife monster ids from dbcharacter::Monster. These types are
+    // faction 7 (gaea), which is hostile to accord in FactionRelations.
+    private const uint CrystiteAranhaWorker = 1184;
+    private const uint CrystiteAranhaSieger = 1198;
+    private const uint SpittingThresher = 506;
+
     private static readonly uint _updateFrequency = ThumperState.THUMPING.CountdownTime() / 100;
+    private readonly List<ulong> _attackerIds = new();
     private readonly ThumperEntity _thumper;
     private ulong _lastUpdate;
+    private ulong _nextWaveAt;
+    private int _waveNumber;
 
     public Thumper(IShard shard, ulong entityId, HashSet<INetworkPlayer> participants, ThumperEntity thumperEntity)
         : base(shard, entityId, participants)
@@ -36,6 +64,17 @@ public class Thumper : BaseEncounter, IInteractionHandler
 
     public override void OnUpdate(ulong currentTime)
     {
+        if (_thumper.IsDestroyed)
+        {
+            OnFailure();
+            return;
+        }
+
+        if (_thumper.StateInfo.State == (byte)ThumperState.THUMPING)
+        {
+            TrySpawnWave(currentTime);
+        }
+
         if (Shard.CurrentTime >= _thumper.StateInfo.CountdownTime)
         {
             switch ((ThumperState)_thumper.StateInfo.State)
@@ -76,10 +115,107 @@ public class Thumper : BaseEncounter, IInteractionHandler
 
     public override void OnSuccess()
     {
+        CleanupAttackers();
+
         Shard.EncounterMan.StopUpdatingEncounter(this);
 
         Shard.EntityMan.Remove(_thumper);
 
         base.OnSuccess();
+    }
+
+    /// <summary>The thumper is destroyed. Remove the attackers and the thumper.</summary>
+    public override void OnFailure()
+    {
+        CleanupAttackers();
+
+        Shard.EncounterMan.StopUpdatingEncounter(this);
+
+        Shard.EntityMan.Remove(_thumper);
+
+        base.OnFailure();
+    }
+
+    /// <summary>
+    ///     Spawns attack waves while the thumper drills. The waves grow with
+    ///     the wave number. Each wave spawns on a ring around the thumper.
+    ///     One half of each wave gets an order to attack the thumper. The
+    ///     other half uses the default AI behavior, which prefers players.
+    /// </summary>
+    private void TrySpawnWave(ulong currentTime)
+    {
+        var influence = Shard.Hives.InfluenceAt(_thumper.Position, out var hive);
+
+        if (_nextWaveAt == 0)
+        {
+            // Near a hive center, the first eruption comes fast
+            _nextWaveAt = currentTime + (influence > 0.4f ? HiveFirstWaveDelayMs : FirstWaveDelayMs);
+            return;
+        }
+
+        if (currentTime < _nextWaveAt)
+        {
+            return;
+        }
+
+        // A position nearer to the hive center gives faster waves
+        var interval = WaveIntervalMs - (ulong)((WaveIntervalMs - HiveWaveIntervalMs) * influence);
+        _nextWaveAt = currentTime + interval;
+        _waveNumber++;
+
+        // Remove the ids of attackers that no longer exist
+        _attackerIds.RemoveAll(id => !Shard.Entities.ContainsKey(id));
+
+        var maxAlive = MaxAliveAttackers;
+        if (hive != null && influence > 0f)
+        {
+            maxAlive = Math.Max(MaxAliveAttackers, (int)(hive.Burst * influence));
+        }
+
+        var budget = maxAlive - _attackerIds.Count;
+        var waveSize = Math.Min(Math.Min(2 + _waveNumber + (int)(influence * 12), HiveMaxWaveSize), budget);
+
+        for (var i = 0; i < waveSize; i++)
+        {
+            // The first slots of later waves carry the heavy types
+            var typeId = CrystiteAranhaWorker;
+            if (_waveNumber >= 2 && i == 0)
+            {
+                typeId = CrystiteAranhaSieger;
+            }
+            else if (_waveNumber >= 4 && i == 1)
+            {
+                typeId = SpittingThresher;
+            }
+
+            var angle = Rng.NextDouble() * Math.PI * 2;
+            var radius = SpawnRadiusMin + ((float)Rng.NextDouble() * (SpawnRadiusMax - SpawnRadiusMin));
+            var offset = new Vector3((float)Math.Cos(angle) * radius, (float)Math.Sin(angle) * radius, 0.5f);
+
+            // Put the spawn ring on the terrain. The thumper Z plus a flat
+            // offset is wrong when the thumper is on a slope.
+            var spawnPosition = _thumper.Position + offset;
+            var ground = Shard.Physics.GetGroundHeight(spawnPosition);
+            if (ground.HasValue)
+            {
+                spawnPosition.Z = ground.Value + 0.5f;
+            }
+
+            var attacker = Shard.EntityMan.SpawnCharacter(typeId, spawnPosition);
+            _attackerIds.Add(attacker.EntityId);
+
+            if (i % 2 == 0)
+            {
+                Shard.AI.IssueOrder(attacker.EntityId, new AttackEntityOrder(_thumper.EntityId));
+            }
+        }
+    }
+
+    private void CleanupAttackers()
+    {
+        foreach (var id in _attackerIds)
+        {
+            Shard.EntityMan.Remove(id);
+        }
     }
 }

--- a/UdpHosts/GameServer/Systems/EntityManager/EntityManager.cs
+++ b/UdpHosts/GameServer/Systems/EntityManager/EntityManager.cs
@@ -1193,7 +1193,15 @@ public class EntityManager
             return;
         }
 
-        _scopedPlayersByEntity[entity.EntityId].Add(player);
+        // The entity can die or despawn while its scope-in request waits in
+        // the queue. NPCs that die in combat make this frequent. A direct
+        // index then stops the server with a KeyNotFoundException.
+        if (!_scopedPlayersByEntity.TryGetValue(entity.EntityId, out var scopedPlayers))
+        {
+            return;
+        }
+
+        scopedPlayers.Add(player);
 
         if (entity is CharacterEntity character)
         {
@@ -1433,7 +1441,11 @@ public class EntityManager
             return;
         }
 
-        _scopedPlayersByEntity[entity.EntityId].Remove(player);
+        // The entity can already be removed. Refer to the same guard in ScopeIn.
+        if (_scopedPlayersByEntity.TryGetValue(entity.EntityId, out var scopedPlayers))
+        {
+            scopedPlayers.Remove(player);
+        }
 
         if (entity is CharacterEntity character)
         {

--- a/UdpHosts/GameServer/Systems/MovementRelay/MovementRelay.cs
+++ b/UdpHosts/GameServer/Systems/MovementRelay/MovementRelay.cs
@@ -71,6 +71,20 @@ public class MovementRelay
         client.NetChannels[ChannelType.UnreliableGss].SendMessage(confirmedPose, character.EntityId);
 
         // Forward update to remote clients
+        BroadcastCharacterPose(character, sendJumpActioned, input.ShortTime);
+    }
+
+    /// <summary>
+    ///     Sends the current pose of a character to all playing clients.
+    ///     The AI engine also uses this method for server-moved NPCs.
+    /// </summary>
+    public void BroadcastCharacterPose(Entities.Character.CharacterEntity character, bool sendJumpActioned = false, ushort jumpShortTime = 0)
+    {
+        // Keep the physics body in sync for server-moved characters (AI).
+        // ProcessMovementInput does this for players, but no code did it
+        // for NPCs. NPC hitboxes then stayed at their spawn position.
+        _shard.Physics.UpdateEntity(character);
+
         var currentPose = new CurrentPoseUpdate
         {
             Data = new AeroMessages.GSS.CurrentPoseUpdateData
@@ -90,7 +104,7 @@ public class MovementRelay
             {
                 if (sendJumpActioned)
                 {
-                    remoteClient.NetChannels[ChannelType.UnreliableGss].SendMessage(new JumpActioned { ShortTime = input.ShortTime }, character.EntityId);
+                    remoteClient.NetChannels[ChannelType.UnreliableGss].SendMessage(new JumpActioned { ShortTime = jumpShortTime }, character.EntityId);
                 }
 
                 remoteClient.NetChannels[ChannelType.UnreliableGss].SendMessage(currentPose, character.EntityId);

--- a/UdpHosts/GameServer/Systems/World/HiveIndex.cs
+++ b/UdpHosts/GameServer/Systems/World/HiveIndex.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Numerics;
+using System.Text.Json;
+using Serilog;
+
+namespace GameServer.Systems.World;
+
+public record HiveSite(string Name, float X, float Y, float Z, float Radius, int Burst);
+
+/// <summary>
+///     Authored underground-population sites. In the game fiction, aranhas
+///     stay below the ground until seismic activity wakes them. A thumper
+///     that drills near a hive site wakes a dense attack instead of the
+///     small default waves. Place sites in the game with the admin command
+///     "hive add". Sites persist as one JSON file for each zone.
+/// </summary>
+public class HiveIndex
+{
+    private static readonly JsonSerializerOptions _jsonOptions = new() { WriteIndented = true };
+    private readonly ILogger _logger = Log.ForContext<HiveIndex>();
+    private readonly string _path;
+    private readonly object _lock = new();
+    private List<HiveSite> _sites = new();
+
+    public HiveIndex(string dataDir, uint zoneId)
+    {
+        _path = string.IsNullOrWhiteSpace(dataDir)
+            ? null
+            : Path.Combine(dataDir, $"hives_{zoneId}.json");
+        Load();
+    }
+
+    public IReadOnlyList<HiveSite> Sites
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _sites.ToList();
+            }
+        }
+    }
+
+    public void Add(HiveSite site)
+    {
+        lock (_lock)
+        {
+            _sites.Add(site);
+            Save();
+        }
+
+        _logger.Information("Hive site added: {Name} at ({X},{Y},{Z}) radius {Radius} burst {Burst}", site.Name, site.X, site.Y, site.Z, site.Radius, site.Burst);
+    }
+
+    public int Clear()
+    {
+        lock (_lock)
+        {
+            var count = _sites.Count;
+            _sites.Clear();
+            Save();
+            return count;
+        }
+    }
+
+    /// <summary>
+    ///     Returns the hive influence at a position, between 0 and 1. The
+    ///     value falls linearly from 1 at the center of the strongest site
+    ///     to 0 at its radius.
+    /// </summary>
+    public float InfluenceAt(Vector3 position, out HiveSite strongest)
+    {
+        strongest = null;
+        var best = 0f;
+        lock (_lock)
+        {
+            foreach (var site in _sites)
+            {
+                var dx = position.X - site.X;
+                var dy = position.Y - site.Y;
+                var distance = MathF.Sqrt((dx * dx) + (dy * dy));
+                if (distance >= site.Radius)
+                {
+                    continue;
+                }
+
+                var falloff = 1f - (distance / site.Radius);
+                if (falloff > best)
+                {
+                    best = falloff;
+                    strongest = site;
+                }
+            }
+        }
+
+        return best;
+    }
+
+    private void Load()
+    {
+        if (_path == null || !File.Exists(_path))
+        {
+            return;
+        }
+
+        try
+        {
+            _sites = JsonSerializer.Deserialize<List<HiveSite>>(File.ReadAllText(_path)) ?? new List<HiveSite>();
+            _logger.Information("Loaded {Count} hive sites from {Path}", _sites.Count, _path);
+        }
+        catch (Exception ex)
+        {
+            _logger.Error(ex, "Failed to load hive sites from {Path}", _path);
+        }
+    }
+
+    private void Save()
+    {
+        if (_path == null)
+        {
+            return;
+        }
+
+        Directory.CreateDirectory(Path.GetDirectoryName(_path)!);
+        File.WriteAllText(_path, JsonSerializer.Serialize(_sites, _jsonOptions));
+    }
+}


### PR DESCRIPTION
﻿(note: I'm going to be real with you lads. This PR was almost entirely
done by Fable 5 for the creation of the engine and GPT 5.6 Sol using Ghidra
for the reverse engineering. There was alot of input and testing done by me.
It works but there is still alot of work for ai to be done. what helped tremendously,
was building my own tools for the help of the reverse engineering. that will come shortly.)

Replaces the AIEngine stub with a complete server-side NPC brain system,
developed and play-tested against live gameplay on the Firefall client:

- Brains: one BrainState per living NPC, 4 Hz think, target selection with
  memory, leash and return-home, per-entity passive override
- Orders API: AttackEntity / DefendPoint / MoveTo / FollowEntity records as
  the seam between content (encounters, missions) and brains
- Behavior profiles derived from SDB data only (no per-monster config):
  speeds and faction from the monster row, movement class from the rig name
  (ground / flying / stationary / climber), combat style from real weapon
  ranges (melee / ranged / sniper / artillery hold distances)
- Combat: ballistic aim solutions from ammunition gravity and speed (low
  arc, high arc for artillery and blocked muzzles, 45-degree maximum-reach,
  hold-fire when the target is above ballistic reach), muzzle-blocked
  probing, cliff/verticality handling, visible NPC projectiles via
  AbilityProjectileFired
- Creature separation: body-width discs prevent packs from stacking into
  one point
- Species layer: partial-class files per species; AIEngine.Aranha.cs ships
  first with hull climbing and latching, per-NPC perch points, pounce leaps
  at players, random leaps onto thumper hulls, and pack-hunting roles
  (direct attackers, circling flankers, leapers, per-NPC gait)

The thumper encounter gets its defense gameplay on top of the AI
(second commit):

- Escalating attack waves while the thumper drills, spawned on a
  terrain-snapped ring: workers first, a sieger from wave 2, a spitting
  thresher from wave 4. Half of each wave is ordered onto the thumper via
  the Orders API; the other half runs default AI and hunts players.
- Thumper health: attackers reduce its integrity; at zero the thumper is
  destroyed and the encounter fails.
- On both endings - the thumper is destroyed, or it completes and leaves -
  all wave-spawned enemies are removed with it.
- Hive sites (HiveIndex + "hive add | list | clear" admin command):
  authored underground-population zones, persisted as JSON per zone.
  Thumping inside a hive wakes a dense, fast eruption instead of the
  default trickle - wave interval, size, and alive cap all scale with
  distance to the hive center.

Also fixes a crash found while testing this PR with LoadMapsCollision
enabled (third commit): SegmentRayCast read a body handle from a static
collidable when a projectile hit zone terrain, which stops the process
with a Bepu assertion.

New admin commands:

- `hive add [radius] [burst]` - plants a hive site at your position
  (defaults: radius 120 m, burst 50). Thumping inside the zone will result
  with the death of the thumper, its a dense wave, thumping near the edges
  will have a falloff.
- `hive list` - lists the hive sites of the zone with distance to you
- `hive clear` - removes all hive sites of the zone
- `npcfx show | muzzle <fraction> | hardpoint <id> | offset <x> <y> <z>` -
  live-tunes the NPC projectile FX anchoring (muzzle height on the rig
  capsule, client hardpoint, visual offset)
- `npcfx aimpoint` - firing-range debug mode: armed NPCs stand and fire at
  a fixed point instead of hunting players. (this is used for finetuning,
  the ai in the engine has a firing offset of 0,0,0 which will result in
  some of them unable to shoot)
- `pacify <on|off> [all]` - toggles NPC aggression for the admin target or
  for every live NPC. Useful for finetuning attacks

Supporting additions:
- PhysicsEngine.GetGroundHeight: static-geometry ground probe with an
  optional walkable kinematic body (lets climbers walk on thumper hulls)
- MovementRelay.BroadcastCharacterPose: extracted from CharacterMovementInput
  and reused for server-moved NPCs (also keeps NPC physics bodies in sync)
- ThumperEntity: CurrentHealth / Damage / IsAttackable / IsDestroyed
- CharacterEntity.GetNpcMuzzleHeight: muzzle height from the scaled rig capsule

Not in this PR, coming as follow-ups: mesh-accurate NPC hitboxes built
from bMesh render geometry (we have this working; it needs a careful merge
with the new pose-shape hit system from the weapon-sim update), and the
species roster work for the remaining aranha variants.

All comments follow ASD-STE100 (Simplified Technical English).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
