### PR TITLE
Improve Chunk generation performance

### DIFF
--- a/Lib/Shared.Collision/Chunk/ChunkFileReader.cs
+++ b/Lib/Shared.Collision/Chunk/ChunkFileReader.cs
@@ -92,21 +92,36 @@ public static class ChunkFileReader
         var dataStart = 16 + (int)rootLength;
         var offset = dataStart;
 
+        // Compute block offsets sequentially, decompress and parse in parallel
+        var decompressTasks = new List<Action>(chunk.Lod.Count * 2);
+
         foreach (var lod in chunk.Lod)
         {
-            var sharedBlock = new byte[lod.CompressedSharedSize];
-            Array.Copy(data, offset, sharedBlock, 0, (int)lod.CompressedSharedSize);
-            lod.SharedDecompressed = DecompressBlock(sharedBlock, (int)lod.UncompressedSharedSize);
-            lod.SharedLayers = WorldLayerParser.ParseLayers(lod.SharedDecompressed, ChunkLodType);
-            offset += (int)lod.CompressedSharedSize;
+            var sharedOffset = offset;
+            var sharedSize = (int)lod.CompressedSharedSize;
+            var sharedUncompressedSize = (int)lod.UncompressedSharedSize;
+            decompressTasks.Add(() =>
+            {
+                var sharedBlock = new byte[sharedSize];
+                Array.Copy(data, sharedOffset, sharedBlock, 0, sharedSize);
+                lod.SharedDecompressed = DecompressBlock(sharedBlock, sharedUncompressedSize);
+                lod.SharedLayers = WorldLayerParser.ParseLayers(lod.SharedDecompressed, ChunkLodType);
+            });
+            offset += sharedSize;
 
             foreach (var sc in lod.SubChunks)
             {
-                var scBlock = new byte[sc.CompressedSize];
-                Array.Copy(data, offset, scBlock, 0, (int)sc.CompressedSize);
-                sc.Decompressed = DecompressBlock(scBlock, (int)sc.UncompressedSize);
-                sc.Layers = WorldLayerParser.ParseLayers(sc.Decompressed, ChunkSubChunkType);
-                offset += (int)sc.CompressedSize;
+                var scOffset = offset;
+                var scSize = (int)sc.CompressedSize;
+                var scUncompressedSize = (int)sc.UncompressedSize;
+                decompressTasks.Add(() =>
+                {
+                    var scBlock = new byte[scSize];
+                    Array.Copy(data, scOffset, scBlock, 0, scSize);
+                    sc.Decompressed = DecompressBlock(scBlock, scUncompressedSize);
+                    sc.Layers = WorldLayerParser.ParseLayers(sc.Decompressed, ChunkSubChunkType);
+                });
+                offset += scSize;
             }
         }
 
@@ -114,6 +129,15 @@ public static class ChunkFileReader
         {
             throw new InvalidDataException(
                 $"Data mismatch: expected 0x{data.Length:X}, got 0x{offset:X}");
+        }
+
+        try
+        {
+            Parallel.ForEach(decompressTasks, task => task());
+        }
+        catch (AggregateException ex)
+        {
+            throw ex.Flatten().InnerExceptions[0];
         }
 
         return chunk;

--- a/Lib/Shared.Collision/Tagfile/Binary/TagfileDictionaryParser.cs
+++ b/Lib/Shared.Collision/Tagfile/Binary/TagfileDictionaryParser.cs
@@ -201,12 +201,9 @@ public class TagfileDictionaryParser
 
     private static object? ConvertObjectRefOrEmbedded(TagfileParser.ObjectData objData, TagfileParser.BinaryTagfile binary)
     {
-        foreach (var kvp in binary.Objects)
+        if (objData.BinIdx != 0 && binary.Objects.TryGetValue(objData.BinIdx, out var stored) && ReferenceEquals(stored, objData))
         {
-            if (ReferenceEquals(kvp.Value, objData))
-            {
-                return TagfileParser.ObjectRefName(kvp.Key);
-            }
+            return TagfileParser.ObjectRefName(objData.BinIdx);
         }
 
         var allData = ConvertMembers(objData, binary);


### PR DESCRIPTION
I've done a small-ish profiling session and improved a bunch of things in Bitter and FauFau. Those changes and the changes in this PR more or less halved the chuck cold start for me. Since it's a bunch of parallel processing, it largely depends on the CPU it runs on.

The good news is also, that once a new SharpCompression version lands, we likely get a another noticeable performance improvement, as they've done a bunch of improvements in the LZMA decoder.

As I haven't written the Chunk loader, I thought @Xsear might want to have a look at the changes, before merging.

- Before we were doing a O(n) look up, which turns rather costly, even though we can look it up in O(1) when it's already known.
- The decompression and parsing was single-threaded, even though the data doesn't overlap. Throwing a Parallel.For at it, churns through the chunks noticeably faster.